### PR TITLE
Escape RegExp curly brace

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function expand(str, isTop) {
   var isOptions = /^(.*,)+(.+)?$/.test(m.body);
   if (!isSequence && !isOptions) {
     // {a},b}
-    if (m.post.match(/,.*}/)) {
+    if (m.post.match(/,.*\}/)) {
       str = m.pre + '{' + m.body + escClose + m.post;
       return expand(str);
     }


### PR DESCRIPTION
Escape '}' in regular expression for better compatibility with other
JavaScript interpreters. It seems like `Ducktype` is not able to
properly parse `brace-expansion` due to the unescaped curly brace.

See: svaarala/duktape#74