### PR TITLE
Remove concat-map dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var concatMap = require('concat-map');
 var balanced = require('balanced-match');
 
 module.exports = expandTop;
@@ -185,7 +184,10 @@ function expand(str, isTop) {
       N.push(c);
     }
   } else {
-    N = concatMap(n, function(el) { return expand(el, false) });
+    N = [];
+    for (var i = 0; i < n.length; ++i) {
+      [].push.apply(N, expand(n[i], false));
+    }
   }
 
   for (var j = 0; j < N.length; j++) {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "bench": "matcha test/perf/bench.js"
   },
   "dependencies": {
-    "balanced-match": "^0.4.1",
-    "concat-map": "0.0.1"
+    "balanced-match": "^0.4.1"
   },
   "devDependencies": {
     "matcha": "^0.7.0",


### PR DESCRIPTION
We use the module `concat-map` to concatenate the result of mapping a function over an array. Therefore I think we can simply remove the dependency and solve that little task ourselves.

`concat-map` also checks whether the function result is an Array and if not, it just adds it as a single element to the resulting array. But as the function `expand()` always returns arrays, we don't need that feature.