### PR TITLE
Update travis to supported node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
-  - "4"
-  - "6"
-  - "7"
   - "10"
+  - "12"
+  - "14"


### PR DESCRIPTION
Updated travis config to test against the currently supported versions on node (10, 12 and 14). Might be worth doing to reconsider #32 since node 4 lost support two years ago too.