### PR TITLE
fix(dollar): consider \$ expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ function expand(str, isTop) {
     }
   } else {
     if(/\\\$$/.test(pre)){
-      pre = pre.substring(0,pre.length - 3) + '$';
+      pre = pre.substring(0,pre.length - 2) + '$';
     }
     const isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body);
     const isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body);

--- a/index.js
+++ b/index.js
@@ -130,25 +130,29 @@ function expand(str, isTop) {
   if (!m) return [str];
 
   // no need to expand pre, since it is guaranteed to be free of brace-sets
-  const pre = m.pre;
+  let pre = m.pre;
   const post = m.post.length
     ? expand(m.post, false)
     : [''];
 
-  if (/\$$/.test(m.pre)) {
+  if (/\$$/.test(pre) && !/\\\$$/.test(pre)) {
     for (let k = 0; k < post.length; k++) {
       const expansion = pre+ '{' + m.body + '}' + post[k];
       expansions.push(expansion);
     }
   } else {
+    if(/\\\$$/.test(pre)){
+      pre = pre.substring(0,pre.length - 3) + '$';
+    }
     const isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body);
     const isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body);
     const isSequence = isNumericSequence || isAlphaSequence;
     const isOptions = m.body.indexOf(',') >= 0;
+
     if (!isSequence && !isOptions) {
       // {a},b}
       if (m.post.match(/,.*\}/)) {
-        str = m.pre + '{' + m.body + escClose + m.post;
+        str = pre + '{' + m.body + escClose + m.post;
         return expand(str);
       }
       return [str];
@@ -164,7 +168,7 @@ function expand(str, isTop) {
         n = expand(n[0], false).map(embrace);
         if (n.length === 1) {
           return post.map(function(p) {
-            return m.pre + n[0] + p;
+            return pre + n[0] + p;
           });
         }
       }

--- a/test/dollar.js
+++ b/test/dollar.js
@@ -7,6 +7,7 @@ test('ignores ${', function(t) {
   t.deepEqual(expand('${a,b}${c,d}{e,f}'), ['${a,b}${c,d}e','${a,b}${c,d}f']);
   t.deepEqual(expand('{a,b}${c,d}${e,f}'), ['a${c,d}${e,f}','b${c,d}${e,f}']);
   t.deepEqual(expand('{a,b}\\${c,d}\\${e,f}'), ['a$c$e','a$c$f', 'a$d$e', 'a$d$f', 'b$c$e', 'b$c$f', 'b$d$e', 'b$d$f']);
+  t.deepEqual(expand('{a,b}c\\${d,e}'), ['ac$d','ac$e', 'bc$d', 'bc$e']);
   t.deepEqual(expand('${a,b}${c,d}{1..3}'), ['${a,b}${c,d}1','${a,b}${c,d}2','${a,b}${c,d}3']);
   t.deepEqual(expand('x${a,b}x${c,d}x'), ['x${a,b}x${c,d}x']);
   t.end();

--- a/test/dollar.js
+++ b/test/dollar.js
@@ -6,6 +6,8 @@ test('ignores ${', function(t) {
   t.deepEqual(expand('${a,b}${c,d}'), ['${a,b}${c,d}']);
   t.deepEqual(expand('${a,b}${c,d}{e,f}'), ['${a,b}${c,d}e','${a,b}${c,d}f']);
   t.deepEqual(expand('{a,b}${c,d}${e,f}'), ['a${c,d}${e,f}','b${c,d}${e,f}']);
+  t.deepEqual(expand('${x,y}'), ['${x,y}']);
+  t.deepEqual(expand('\\${x,y}'), ['$x','$y']);
   t.deepEqual(expand('{a,b}\\${c,d}\\${e,f}'), ['a$c$e','a$c$f', 'a$d$e', 'a$d$f', 'b$c$e', 'b$c$f', 'b$d$e', 'b$d$f']);
   t.deepEqual(expand('{a,b}c\\${d,e}'), ['ac$d','ac$e', 'bc$d', 'bc$e']);
   t.deepEqual(expand('${a,b}${c,d}{1..3}'), ['${a,b}${c,d}1','${a,b}${c,d}2','${a,b}${c,d}3']);

--- a/test/dollar.js
+++ b/test/dollar.js
@@ -6,6 +6,7 @@ test('ignores ${', function(t) {
   t.deepEqual(expand('${a,b}${c,d}'), ['${a,b}${c,d}']);
   t.deepEqual(expand('${a,b}${c,d}{e,f}'), ['${a,b}${c,d}e','${a,b}${c,d}f']);
   t.deepEqual(expand('{a,b}${c,d}${e,f}'), ['a${c,d}${e,f}','b${c,d}${e,f}']);
+  t.deepEqual(expand('{a,b}\\${c,d}\\${e,f}'), ['a$c$e','a$c$f', 'a$d$e', 'a$d$f', 'b$c$e', 'b$c$f', 'b$d$e', 'b$d$f']);
   t.deepEqual(expand('${a,b}${c,d}{1..3}'), ['${a,b}${c,d}1','${a,b}${c,d}2','${a,b}${c,d}3']);
   t.deepEqual(expand('x${a,b}x${c,d}x'), ['x${a,b}x${c,d}x']);
   t.end();


### PR DESCRIPTION
If I do this in my terminal:
```bash
echo {a,b}\${c,d}\${e,f}
-> a$c$e a$c$f a$d$e a$d$f b$c$e b$c$f b$d$e b$d$f
```
now in brace-expand it do not match, so this pr is trying to fix this behavior