### PR TITLE
feat: use string replaces instead of splits

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,16 @@ const escOpen = '\0OPEN' + Math.random() + '\0'
 const escClose = '\0CLOSE' + Math.random() + '\0'
 const escComma = '\0COMMA' + Math.random() + '\0'
 const escPeriod = '\0PERIOD' + Math.random() + '\0'
+const escSlashPattern = new RegExp(escSlash, 'g');
+const escOpenPattern = new RegExp(escOpen, 'g');
+const escClosePattern = new RegExp(escClose, 'g');
+const escCommaPattern = new RegExp(escComma, 'g');
+const escPeriodPattern = new RegExp(escPeriod, 'g');
+const slashPattern = /\\\\/g;
+const openPattern = /\\{/g;
+const closePattern = /\\}/g;
+const commaPattern = /\\,/g;
+const periodPattern = /\\./g;
 
 /**
  * @return {number}
@@ -19,22 +29,22 @@ function numeric (str) {
  * @param {string} str
  */
 function escapeBraces (str) {
-  return str.split('\\\\').join(escSlash)
-    .split('\\{').join(escOpen)
-    .split('\\}').join(escClose)
-    .split('\\,').join(escComma)
-    .split('\\.').join(escPeriod)
+  return str.replace(slashPattern, escSlash)
+    .replace(openPattern, escOpen)
+    .replace(closePattern, escClose)
+    .replace(commaPattern, escComma)
+    .replace(periodPattern, escPeriod);
 }
 
 /**
  * @param {string} str
  */
 function unescapeBraces (str) {
-  return str.split(escSlash).join('\\')
-    .split(escOpen).join('{')
-    .split(escClose).join('}')
-    .split(escComma).join(',')
-    .split(escPeriod).join('.')
+  return str.replace(escSlashPattern, '\\')
+    .replace(escOpenPattern, '{')
+    .replace(escClosePattern, '}')
+    .replace(escCommaPattern, ',')
+    .replace(escPeriodPattern, '.');
 }
 
 /**


### PR DESCRIPTION
Using a split/join results in a lot of garbage collection for the unused arrays, along with being fairly slow. This just moves to using a RegExp replace instead.

Bench result:
> 3,410 ops/sec

Bench result on main:
> 1,150 ops/sec

let me know if you want any changes. i'm not so happy about the amount of new consts lying around, but figured it is simpler than having some set of pairs i iterate through.

also @juliangruber, would you ever consider doing patches to 2.x? many millions of the downloads are still CJS (2.x), it would be good to get this perf gain out to them since they're unlikely to move to ESM sooner