### PR TITLE
chore: support node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ['main']
   pull_request_target:
     paths:
       - 'src/**'
@@ -12,6 +12,8 @@ on:
       - '*.ts'
       - 'lib/**'
       - 'scripts/**'
+      - '.github/workflows/ci.yml'
+      - 'package.json'
   workflow_dispatch:
 
 permissions:
@@ -21,7 +23,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [18.x, 20.x, 22.x, 24.x, 25.x]
         platform:
         - os: ubuntu-latest
           shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/node": "^25.2.1",
         "mkdirp": "^3.0.1",
         "prettier": "^3.3.2",
-        "tap": "^21.5.0",
+        "tap": "^21.6.2",
         "tshy": "^3.0.2",
         "typedoc": "^0.28.5"
       },
@@ -178,6 +178,19 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/@isaacs/which": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@isaacs/which/-/which-7.0.4.tgz",
+      "integrity": "sha512-qXToWZFY9CKvWsveV3R5VHNJLQkHTIJXO9J4Xa1UgNwVCRA2LEsmvWC84MIdnezFLsjn2Q+GzbL/8yVF1/ozJw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -266,22 +279,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@npmcli/git/node_modules/which": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
-      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@npmcli/installed-package-contents": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
@@ -310,9 +307,9 @@
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.4.tgz",
-      "integrity": "sha512-0wInJG3j/K40OJt/33ax47WfWMzZTm6OQxB9cDhTt5huCP2a9g2GnlsxmfN+PulItNPIpPrZ+kfwwUil7eHcZQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+      "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -322,7 +319,7 @@
         "json-parse-even-better-errors": "^5.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.5.3",
-        "validate-npm-package-license": "^3.0.4"
+        "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -336,22 +333,6 @@
       "license": "ISC",
       "dependencies": {
         "which": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@npmcli/promise-spawn/node_modules/which": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
-      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -380,22 +361,6 @@
         "node-gyp": "^12.1.0",
         "proc-log": "^6.0.0",
         "which": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@npmcli/run-script/node_modules/which": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
-      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -542,9 +507,9 @@
       }
     },
     "node_modules/@tapjs/after": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/after/-/after-3.3.1.tgz",
-      "integrity": "sha512-/RZb0DZxfHP74ursSByTpgKU6jVUtNOtoQ3/prf76+5+G7Q7D7QIQtlrH3bUgk84DI89j+4Nc2DTkMCOLy7BWQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/after/-/after-3.3.4.tgz",
+      "integrity": "sha512-Y8DL0F9Ux6Swe7b5g4qLFgJUEFrVr5fhmVOENw4D/x7rDRyx/3c86Ya1p9iJrpkE2RnvdGq9AxR/rTM137Y7Lg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -554,13 +519,13 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/after-each": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/after-each/-/after-each-4.3.1.tgz",
-      "integrity": "sha512-kgRbmhKisIl31FsCxFkDmZLNj0qCdNte0aarVLsaFq1LVJOtpITdBfnuiKigrLj4Go9XiASmIpGrU8h1uYF2Xw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/after-each/-/after-each-4.3.4.tgz",
+      "integrity": "sha512-TM1OWz7Ht3aimbT/MLYnoywI9SBGsTus6TQ+94n1yjr1izO3K21PP5Q9UYdqZ2Qq1WiZmGa+CZKUZANUn1ZcvQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -570,13 +535,13 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/asserts": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/asserts/-/asserts-4.3.1.tgz",
-      "integrity": "sha512-PyBE1/umvg/o9Ntg3gryWaamCFHhMV0zSdoD6n5saexa8AYUb9XM6XA4y7uXRisdSFVVnD8/yX0OAWsQhryE0g==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/asserts/-/asserts-4.3.4.tgz",
+      "integrity": "sha512-1kf2q0oQ7LCZKy5l4Oe7/ZVijhJ9YxbS4qmqGtj7cYwOw4Q78KNLwthh14c9EBbI2QHKUDS2LaLM8a1qMLmPiA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -592,13 +557,13 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/before": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/before/-/before-4.3.1.tgz",
-      "integrity": "sha512-zxa+DrruCGJhTQCLjYa8nfyYihLsWBWCEgiSvtwOkQKNZhxcaLmH/W85zEWKJ+MnZaa4wVqkyyRkhAM12eq0Lg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/before/-/before-4.3.4.tgz",
+      "integrity": "sha512-53n/8/RktPkbCuZveDTYiplbrzWjFkYAnmYCrFixESsFoUrkfTCPjeCRmojBS14zuRdVe4kLsX6XWYkaUpLdZA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -608,13 +573,13 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/before-each": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/before-each/-/before-each-4.3.1.tgz",
-      "integrity": "sha512-vPCbni80H7/6JtQY2LoO4kiRmuyOwPJXpgR2SRrH9Aq07EVveSlgMkKJxomkbuE5lGr/l6zhO/TZDPnuorSvrg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/before-each/-/before-each-4.3.4.tgz",
+      "integrity": "sha512-WkLsDvCjBrxrRkyhEBpfmGObUsf8Eb+tsqlxnGUG67XbPMkwkP/AoUPonc/g1Nv+pwtR+t5j6maNblrubWuG3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -624,33 +589,33 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/chdir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/chdir/-/chdir-3.3.1.tgz",
-      "integrity": "sha512-8awqiQswpJRtlOdag+wV/ezuX1kv9YKiG3DAKcNVr7exkGr61StL7qV1cdHah2rPAXlJv6blgDIYbR80d3s9qA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/chdir/-/chdir-3.3.4.tgz",
+      "integrity": "sha512-B37eGrs47xseJ7dm9ikhStX7KNqflvZViT2lMqVACeNvoxSpRgy1pu7cPix4wKvBlZCtNYaOD8iDNm+5nDfvSQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/config": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/config/-/config-5.4.1.tgz",
-      "integrity": "sha512-ZK1Zs58ALGWx6Zxd0fDlN9VlGNxoudpXZqjlr2asC/Zu6v5oyilN9CX2r9PWHyTHNe6b/TpfpOvt2gTCTpuROA==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@tapjs/config/-/config-5.5.2.tgz",
+      "integrity": "sha512-GQyKl40fGamoSvT4SsfQfZyaHT8fboNW5OhrA1hhMc34di5j/efiD15VlNVbPGE51BZSs5M3Jw7YukF2/Cg8CA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/core": "4.4.1",
-        "@tapjs/test": "4.3.1",
+        "@tapjs/core": "4.5.2",
+        "@tapjs/test": "4.4.2",
         "chalk": "^5.6.2",
-        "jackspeak": "^4.1.2",
+        "jackspeak": "^4.2.3",
         "polite-json": "^5.0.0",
         "tap-yaml": "4.3.0",
         "walk-up-path": "^4.0.0"
@@ -662,20 +627,20 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1",
-        "@tapjs/test": "4.3.1"
+        "@tapjs/core": "4.5.2",
+        "@tapjs/test": "4.4.2"
       }
     },
     "node_modules/@tapjs/core": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/core/-/core-4.4.1.tgz",
-      "integrity": "sha512-zEeDgt6YNOKXs4NfGGZ1Lz5aLTlHNCUpwvx5hVl7CuL+/noudWZvL39Vy2rKb+zZnTSgF7b34DqGLoy8+jgpfg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@tapjs/core/-/core-4.5.2.tgz",
+      "integrity": "sha512-0KKabYyBN4W2CRgnD0rOhDvexbMLMPuT0OElQTz5ezCsx1QGtuUHP9TmRXEGCJAoeL44Us0L2DxPpS4BUW1KEQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@tapjs/processinfo": "^3.1.9",
         "@tapjs/stack": "4.3.0",
-        "@tapjs/test": "4.3.1",
+        "@tapjs/test": "4.4.2",
         "async-hook-domain": "^4.0.1",
         "diff": "^8.0.2",
         "is-actual-promise": "^1.0.1",
@@ -707,9 +672,9 @@
       }
     },
     "node_modules/@tapjs/filter": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/filter/-/filter-4.3.1.tgz",
-      "integrity": "sha512-oyoqmUcHjYvr5f7LOryVB9ruEtjTiABdwZghx3XgeRnaNiVX3J9J8/xvdctnkbDB7cq3g9Ao2DYzweDl6Zfvhg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/filter/-/filter-4.3.4.tgz",
+      "integrity": "sha512-Bpbahk/Bv30ZfGoDpZVjGhvg8Cq2yqCZcawd+4qtTTSDY+V7GEpdJGu2/2EvwXP+s4PklPx2kFry8X9m6OtAog==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -719,13 +684,13 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/fixture": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/fixture/-/fixture-4.3.1.tgz",
-      "integrity": "sha512-x3w6Ro4H6UAxNSkDTtmz73kVCjZP4TNY2m+wLLiRdi8fa3lCn7WfvHUn9zoATgRFjgOnG4XrXSkjybhqHZ4Ibw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/fixture/-/fixture-4.3.4.tgz",
+      "integrity": "sha512-zRv1vD2H/2abt0S5Yr5ICV/ZaIqXmusBZ6H4Qbih9oE2jvbs6AVDz5Td0adZbWurtHrPLuOFTIz2UsbJfhCCcw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -739,36 +704,36 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/intercept": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/intercept/-/intercept-4.3.1.tgz",
-      "integrity": "sha512-AvfZwFqAh8g+226HRVMUwoHm1ncf6xMHRQfcsPPIMtjnIrbJZjr2S2uM9qTWTnlk2EVgerqfyh3H8R6ykJsGIg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/intercept/-/intercept-4.3.4.tgz",
+      "integrity": "sha512-7ifEMPmp4yKHQ7PqdPwCetipFLvCegbIyKigEDds/p03ZNFJjgF06D9T4vc/m0sA5SKkPrHVTOU0UzaSrliP7w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/after": "3.3.1",
+        "@tapjs/after": "3.3.4",
         "@tapjs/stack": "4.3.0"
       },
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/mock": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/mock/-/mock-4.3.1.tgz",
-      "integrity": "sha512-oiR34RhC0+h0fqLNHkDA5QmQXmVJkujvdGwUEBxR3HzUIKZWp5SfVw4dY2/Lvl33tPBOtsFDFuqnpt3+f6SrXg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@tapjs/mock/-/mock-4.4.2.tgz",
+      "integrity": "sha512-B6SfNWjWCPvjN9CaHe45lEcl2ZFDkQIUoF5jPthwi2mYxHLfyFFEqorZJhguoTs7ToeXvIqquqE/Luk9IeuKBQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/after": "3.3.1",
+        "@tapjs/after": "3.3.4",
         "@tapjs/stack": "4.3.0",
-        "resolve-import": "^2.1.1",
+        "resolve-import": "^2.4.0",
         "walk-up-path": "^4.0.0"
       },
       "engines": {
@@ -778,13 +743,13 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/node-serialize": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/node-serialize/-/node-serialize-4.3.1.tgz",
-      "integrity": "sha512-dOsTr75HFESskVvuv8L6SAw23c2WtF6aoNkaD9SwtbTQZxvZQNGMechWPWYGaMsHB+aB+6EBg1MVnqWHQrOVcw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/node-serialize/-/node-serialize-4.3.4.tgz",
+      "integrity": "sha512-SECDvjBS7NVCiCZ6vEtMwtxxSuR61NHBva+PlIQ1mU0asoTYxV9lpRNEAb9UHFKpquEDlk+bLg2iN01a2nfMuw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -799,7 +764,7 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/processinfo": {
@@ -820,13 +785,13 @@
       }
     },
     "node_modules/@tapjs/reporter": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/reporter/-/reporter-4.4.1.tgz",
-      "integrity": "sha512-kOppWVcv3sa0fmsBrpzwJiUZbwEdhixBAg0J39dUDMDdNIYrefVUSJsi7f1Agi9uRRXeJfZlUw23tII4CV06rQ==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/reporter/-/reporter-4.4.4.tgz",
+      "integrity": "sha512-svWmpJgMQxe4iiKOVr/Hi5kGHJNBDp2Nr8gD0aQuAQ4fp9gOh2LFQXa2Jv7LBKhMjC7UaiW/X7k1qEVk2nOfvg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/config": "5.4.1",
+        "@tapjs/config": "5.5.2",
         "@tapjs/stack": "4.3.0",
         "chalk": "^5.6.2",
         "ink": "^5.2.1",
@@ -847,44 +812,44 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/run": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/run/-/run-4.4.1.tgz",
-      "integrity": "sha512-mVD9FCknr1mkkCv1vMKL2x4pmpka8ArqHufMP8Mb3Etj6blfePNv0Mu75RWVN9bKYzKAkqPGLenDBPb9hnbUgg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@tapjs/run/-/run-4.5.2.tgz",
+      "integrity": "sha512-Oq5YZvoGxEohRWK8P1wHPIAnudEOHPd/bIWawFtRn0ZGvF7bRduZlHpf4eEIrRHKY84G/I3fmC354604cejxiQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/after": "3.3.1",
-        "@tapjs/before": "4.3.1",
-        "@tapjs/config": "5.4.1",
+        "@isaacs/which": "^7.0.4",
+        "@tapjs/after": "3.3.4",
+        "@tapjs/before": "4.3.4",
+        "@tapjs/config": "5.5.2",
         "@tapjs/processinfo": "^3.1.9",
-        "@tapjs/reporter": "4.4.1",
-        "@tapjs/spawn": "4.3.1",
-        "@tapjs/stdin": "4.3.1",
-        "@tapjs/test": "4.3.1",
+        "@tapjs/reporter": "4.4.4",
+        "@tapjs/spawn": "4.3.4",
+        "@tapjs/stdin": "4.3.4",
+        "@tapjs/test": "4.4.2",
         "c8": "^10.1.3",
         "chalk": "^5.6.2",
         "chokidar": "^4.0.2",
         "foreground-child": "^4.0.0",
-        "glob": "^13.0.0",
+        "glob": "^13.0.2",
         "minipass": "^7.0.4",
         "mkdirp": "^3.0.1",
         "node-options-to-argv": "^1.0.0",
         "opener": "^1.5.2",
         "pacote": "^21.0.4",
         "path-scurry": "^2.0.0",
-        "resolve-import": "^2.0.0",
+        "resolve-import": "^2.4.0",
         "rimraf": "^6.0.0",
         "semver": "^7.7.2",
         "signal-exit": "^4.1.0",
         "tap-parser": "18.3.0",
         "tap-yaml": "4.3.0",
         "tcompare": "9.3.0",
-        "trivial-deferred": "^2.0.0",
-        "which": "^5.0.0"
+        "trivial-deferred": "^2.0.0"
       },
       "bin": {
         "tap-run": "dist/esm/index.js"
@@ -896,13 +861,13 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/snapshot": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/snapshot/-/snapshot-4.3.1.tgz",
-      "integrity": "sha512-xPE5yxnck9EhpbH2i60xIB9HxgG39wSyn6Hj+UQal/lDgprbdYNG+36Owdp52TNHOL14GcVO3aiqyOy4UdkN6A==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/snapshot/-/snapshot-4.3.4.tgz",
+      "integrity": "sha512-2sJXaGLJUMakkdJd5iDWRucgyHX7f5eP05m4weqWq9dLzX7p1JFOrWXUwns8RCIY7VX9Vx+4jENlxJOywYjyqg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -917,20 +882,20 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/spawn": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/spawn/-/spawn-4.3.1.tgz",
-      "integrity": "sha512-bQ5Mb0F8Vm07TDe3DYFEzuIN1aCbRyFPYjM6cD62iszT0B4znaXL4PseRXB0VoL9cxJICeNm6AiT0G9PF09z4Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/spawn/-/spawn-4.3.4.tgz",
+      "integrity": "sha512-qQY2SSLkXknpL1kndLS1bCPo9vYKV8Ka93UPIllvDEwaY3oUMghh++EOE4dyUxQPgMFpmoUoj8kSbm2hotevbQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/stack": {
@@ -947,51 +912,51 @@
       }
     },
     "node_modules/@tapjs/stdin": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/stdin/-/stdin-4.3.1.tgz",
-      "integrity": "sha512-wD4bJM+1LmnDkBpR7aLJ6tlwDM/OT0RaiHPFgRrpDv7FB50LeR3h9wh7s+c+Ysc9OgZDkLNLkvG9jIhb937bZA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/stdin/-/stdin-4.3.4.tgz",
+      "integrity": "sha512-0kFeaPEGwNWx8R0z9Uq93/CNhAg+9NbTPZW+GXsjuHQSG125g7VZBNBAg2IMeQmVQ9bUWa3+f5TNp/JnLVvJmg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/test": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/test/-/test-4.3.1.tgz",
-      "integrity": "sha512-NOsYB1VhaSPmWqrvsdeVnUuklNtJwFEQnybPHjVCqq0ecjP/SZKW+nnVzt9ISAPF+FDtQisqgJV2/Y54jzhpgA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@tapjs/test/-/test-4.4.2.tgz",
+      "integrity": "sha512-YuUgTffPNGzodjeHOsaF/j0/5B/bAqtfgwqUkqa3mWdwqzlmB2AcIA6lBtLaQfbjG8wgGNwYfs3McgxkGRqxfA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/ts-node-temp-fork-for-pr-2009": "^10.9.7",
-        "@tapjs/after": "3.3.1",
-        "@tapjs/after-each": "4.3.1",
-        "@tapjs/asserts": "4.3.1",
-        "@tapjs/before": "4.3.1",
-        "@tapjs/before-each": "4.3.1",
-        "@tapjs/chdir": "3.3.1",
-        "@tapjs/filter": "4.3.1",
-        "@tapjs/fixture": "4.3.1",
-        "@tapjs/intercept": "4.3.1",
-        "@tapjs/mock": "4.3.1",
-        "@tapjs/node-serialize": "4.3.1",
-        "@tapjs/snapshot": "4.3.1",
-        "@tapjs/spawn": "4.3.1",
-        "@tapjs/stdin": "4.3.1",
-        "@tapjs/typescript": "3.5.1",
-        "@tapjs/worker": "4.3.1",
-        "glob": "^13.0.0",
-        "jackspeak": "^4.1.2",
+        "@tapjs/after": "3.3.4",
+        "@tapjs/after-each": "4.3.4",
+        "@tapjs/asserts": "4.3.4",
+        "@tapjs/before": "4.3.4",
+        "@tapjs/before-each": "4.3.4",
+        "@tapjs/chdir": "3.3.4",
+        "@tapjs/filter": "4.3.4",
+        "@tapjs/fixture": "4.3.4",
+        "@tapjs/intercept": "4.3.4",
+        "@tapjs/mock": "4.4.2",
+        "@tapjs/node-serialize": "4.3.4",
+        "@tapjs/snapshot": "4.3.4",
+        "@tapjs/spawn": "4.3.4",
+        "@tapjs/stdin": "4.3.4",
+        "@tapjs/typescript": "3.5.4",
+        "@tapjs/worker": "4.3.4",
+        "glob": "^13.0.2",
+        "jackspeak": "^4.2.3",
         "mkdirp": "^3.0.0",
         "package-json-from-dist": "^1.0.0",
-        "resolve-import": "^2.1.1",
+        "resolve-import": "^2.4.0",
         "rimraf": "^6.0.0",
-        "sync-content": "^2.0.1",
+        "sync-content": "^2.0.4",
         "tap-parser": "18.3.0",
-        "tshy": "^3.1.3",
+        "tshy": "^3.3.2",
         "typescript": "5.9",
         "walk-up-path": "^4.0.0"
       },
@@ -1002,13 +967,13 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/typescript": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/typescript/-/typescript-3.5.1.tgz",
-      "integrity": "sha512-4clGpzF1OTjLZYlavI167rCseSVsLpd5ygBAf297o468VEtpRAJPYx1IjoPrnGWC/M5iJadsCrTlIuBYABw81g==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/typescript/-/typescript-3.5.4.tgz",
+      "integrity": "sha512-z8O10CpbPYoHA876Dlg40qXtM058akP76HNQy+EdNE+AhFo7kold4YBgyjYRU7WDWNlp2B/MPgsy/OZ4PRXQWw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1018,20 +983,20 @@
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tapjs/worker": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tapjs/worker/-/worker-4.3.1.tgz",
-      "integrity": "sha512-RInbFaGUH+KsAl/ozRVCMhpXaQPsvwEQ7PiKprpXgKjxjUrzwlkAbFAxo4K79axCWWdm6JUD5pH93n0FJ75jYQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@tapjs/worker/-/worker-4.3.4.tgz",
+      "integrity": "sha512-AvmfwMgJXB/eOwIti/rOvw1l1eHsxUex3lyrhiC6uK5iOmbHWBOFsGHwEfc7Z4eertPM6FUqnZxkxkTEVGueig==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       },
       "peerDependencies": {
-        "@tapjs/core": "4.4.1"
+        "@tapjs/core": "4.5.2"
       }
     },
     "node_modules/@tsconfig/node14": {
@@ -1127,6 +1092,123 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20260220.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260220.1.tgz",
+      "integrity": "sha512-trYXlG98/C7Q7pqnPrKo+ksXrWqWVMncCy2x0VftD2llfL99Z//g2mpB9TmzWeKgb4d1659ESvxTowCGnzMccw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260220.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260220.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260220.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260220.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260220.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260220.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260220.1"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20260220.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260220.1.tgz",
+      "integrity": "sha512-VZQHVaLYTpa3wfCLcFD5cfnegr4iDtzBxV6yh3tys+HYePi4TXuAqct/dmziW0cpCo/UQ2KqAPGxwVO3YMDYJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20260220.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260220.1.tgz",
+      "integrity": "sha512-ieGtyz904rlme8YWauDpCqGbnOQQ5dzUyRKU25I7MNIaoZFf0vK5gMh3SLjHC7ayWxjrCa2ezH4ka8UmyWQcPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20260220.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260220.1.tgz",
+      "integrity": "sha512-wMA63N6XLAkO0Ibq1Qz2zkQHF6oLynYh5+q1YayzWxp1FOas0oJUdNgVbiWeisAT4IEI9SmYtVwJJNTm/cwrwg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20260220.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260220.1.tgz",
+      "integrity": "sha512-nlOOABSQUe6ix/KOsZS3ALZ/sg9rhtp6SKtQnXO8X4+2XUlwVYS6nIrAQ5jG4+OsCvcESttNeHhBw817uNrsuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20260220.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260220.1.tgz",
+      "integrity": "sha512-W7R/5ct/BGuPAmJuKFU0ZuLU2nzLA26XfoaoUHHoTLYRMMuY3LBv+7zKSUTlSGjayeWQ5KtDrfrY72LarWAXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20260220.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260220.1.tgz",
+      "integrity": "sha512-FNXTr2lS1QLUB05jWjkBVwrDierNuxKduQq9ayloENJrsC8GfG1sXkfy8R021+ozP/D1LI/CFUn3hkB2vPXTsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20260220.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260220.1.tgz",
+      "integrity": "sha512-byHRyf4dOuKOADrs43tWyPhmAgqk+XrA/XOsJnGsxUKxPwots+gf9x5kg/IxTbB3QjPsVe/V9QdMl3//sUTCmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/abbrev": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
@@ -1138,9 +1220,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1151,9 +1233,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1896,9 +1978,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1909,18 +1991,47 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz",
-      "integrity": "sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.2",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2171,9 +2282,9 @@
       }
     },
     "node_modules/isexe": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.2.tgz",
-      "integrity": "sha512-mIcis6w+JiQf3P7t7mg/35GKB4T1FQsBOtMIvuKw4YErj5RjtbhcTd5/I30fmkmGMwvI0WlzSNN+27K0QCMkAw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2249,6 +2360,15 @@
       "license": "MIT",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/jsonc-simple-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-simple-parser/-/jsonc-simple-parser-3.0.0.tgz",
+      "integrity": "sha512-0qi9Kuj4JPar4/3b9wZteuPZrTeFzXsQyOZj7hksnReCZN3Vr17Doz7w/i3E9XH7vRkVTHhHES+r1h97I+hfww==",
+      "dev": true,
+      "dependencies": {
+        "reghex": "^3.0.2"
       }
     },
     "node_modules/jsonparse": {
@@ -2415,11 +2535,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -2600,22 +2720,6 @@
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/which": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
-      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -2825,9 +2929,9 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pacote": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.2.0.tgz",
-      "integrity": "sha512-OwidJA8uHuGYxoZhe4DBv3JJqGg4ojjVV5dwvVxRKq+bOBpgYMbYd/onIvSU1sv5nQIsb+zp4/0uqv6giFQVjg==",
+      "version": "21.3.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.3.1.tgz",
+      "integrity": "sha512-O0EDXi85LF4AzdjG74GUwEArhdvawi/YOHcsW6IijKNj7wm8IvEWNF5GnfuxNpQ/ZpO3L37+v8hqdVh8GgWYhg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2887,9 +2991,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -2897,7 +3001,7 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3112,6 +3216,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/reghex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/reghex/-/reghex-3.0.2.tgz",
+      "integrity": "sha512-Zb9DJ5u6GhgqRSBnxV2QSnLqEwcKxHWFA1N2yUa4ZUAO1P8jlWKYtWZ6/ooV6yylspGXJX0O/uNzEv0xrCtwaA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3123,9 +3234,9 @@
       }
     },
     "node_modules/resolve-import": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/resolve-import/-/resolve-import-2.1.1.tgz",
-      "integrity": "sha512-pgTo41KMWjSZNNA4Ptgs+AtB+/w+a2/MDm6VzZiEnt2op2rXHYK/EYdRYhBsPlGN1naYMogJopBoJxtHgGTHEA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/resolve-import/-/resolve-import-2.4.0.tgz",
+      "integrity": "sha512-gLWKdA5tiv5j/D7ipR47u3ovbVfzFPrctTdw2Ulnpmr6PPVVSvPKGNWu09jXVNlOSLLAeD6CA13bjIelpWttSw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3352,17 +3463,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
@@ -3371,9 +3471,9 @@
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3389,9 +3489,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/ssri": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.0.tgz",
-      "integrity": "sha512-yizwGBpbCn4YomB2lzhZqrHLJoqFGXihNbib3ozhqF/cIp5ue+xSmOQrjNasEE62hFxsCcg/V/z23t4n8jMEng==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3558,17 +3658,16 @@
       }
     },
     "node_modules/sync-content": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sync-content/-/sync-content-2.0.3.tgz",
-      "integrity": "sha512-gKE1q9t4qBDkWqJElji6HSM2OBLK6QooA0LjYg5TYJLE7rca95u2/RKpMZ15WfW9Ri3qbFJRfiS0zbSQqvlf4w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sync-content/-/sync-content-2.0.4.tgz",
+      "integrity": "sha512-w3ioiBmbaogob33WdLnuwFk+8tpePI58CTWKqtdAgEqc2hfGuSwP02gPETqNX/3PLS5skv5a1wQR0gbaa2W0XQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^13.0.0",
+        "glob": "^13.0.1",
         "mkdirp": "^3.0.1",
         "path-scurry": "^2.0.0",
-        "rimraf": "^6.0.0",
-        "tshy": "^3.1.0"
+        "rimraf": "^6.0.0"
       },
       "bin": {
         "sync-content": "dist/esm/bin.mjs"
@@ -3581,32 +3680,32 @@
       }
     },
     "node_modules/tap": {
-      "version": "21.5.1",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-21.5.1.tgz",
-      "integrity": "sha512-uhS20sTR4Q+/T2ovawxgVLjdsTQuU+xFz9htRwlx5jwkaWiv+1xes/0ZW5IlO+hlQp9iQH3rj30FNRlnN2ZVtw==",
+      "version": "21.6.2",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-21.6.2.tgz",
+      "integrity": "sha512-rEuxX+EVGQ6JOEyRnLQ80fa7v5s8yutpRA11LAjP6t/B6I0/mTWkaW0NfVoX5XDX3z5x9HVEt2dojSrJLcyp9A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@tapjs/after": "3.3.1",
-        "@tapjs/after-each": "4.3.1",
-        "@tapjs/asserts": "4.3.1",
-        "@tapjs/before": "4.3.1",
-        "@tapjs/before-each": "4.3.1",
-        "@tapjs/chdir": "3.3.1",
-        "@tapjs/core": "4.4.1",
-        "@tapjs/filter": "4.3.1",
-        "@tapjs/fixture": "4.3.1",
-        "@tapjs/intercept": "4.3.1",
-        "@tapjs/mock": "4.3.1",
-        "@tapjs/node-serialize": "4.3.1",
-        "@tapjs/run": "4.4.1",
-        "@tapjs/snapshot": "4.3.1",
-        "@tapjs/spawn": "4.3.1",
-        "@tapjs/stdin": "4.3.1",
-        "@tapjs/test": "4.3.1",
-        "@tapjs/typescript": "3.5.1",
-        "@tapjs/worker": "4.3.1",
-        "resolve-import": "^2.1.1"
+        "@tapjs/after": "3.3.4",
+        "@tapjs/after-each": "4.3.4",
+        "@tapjs/asserts": "4.3.4",
+        "@tapjs/before": "4.3.4",
+        "@tapjs/before-each": "4.3.4",
+        "@tapjs/chdir": "3.3.4",
+        "@tapjs/core": "4.5.2",
+        "@tapjs/filter": "4.3.4",
+        "@tapjs/fixture": "4.3.4",
+        "@tapjs/intercept": "4.3.4",
+        "@tapjs/mock": "4.4.2",
+        "@tapjs/node-serialize": "4.3.4",
+        "@tapjs/run": "4.5.2",
+        "@tapjs/snapshot": "4.3.4",
+        "@tapjs/spawn": "4.3.4",
+        "@tapjs/stdin": "4.3.4",
+        "@tapjs/test": "4.4.2",
+        "@tapjs/typescript": "3.5.4",
+        "@tapjs/worker": "4.3.4",
+        "resolve-import": "^2.4.0"
       },
       "bin": {
         "tap": "dist/esm/run.mjs"
@@ -3879,19 +3978,21 @@
       }
     },
     "node_modules/tshy": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/tshy/-/tshy-3.1.3.tgz",
-      "integrity": "sha512-ZdPC4TpXbSKJDZoRULD8cwv6F1C0t0XK1lPtPWAtWzmMp7b2JL+YcGpmd+pwwP2jHbbOhPebNpGgg2iwmscSAA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/tshy/-/tshy-3.3.2.tgz",
+      "integrity": "sha512-vOIXkqMtBWNjKUR/c99+6N50LhWdnKG1xE3+5wf8IPdzxx2lcIFPvbGgFdBBgoTMbdNb8mz06MUm7hY+TFnJcw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
+        "@typescript/native-preview": "^7.0.0-dev.20260218.1",
         "chalk": "^5.6.2",
         "chokidar": "^4.0.3",
         "foreground-child": "^4.0.0",
+        "jsonc-simple-parser": "^3.0.0",
         "minimatch": "^10.0.3",
         "mkdirp": "^3.0.1",
         "polite-json": "^5.0.0",
-        "resolve-import": "^2.1.1",
+        "resolve-import": "^2.4.0",
         "rimraf": "^6.1.2",
         "sync-content": "^2.0.3",
         "typescript": "^5.9.3",
@@ -4069,17 +4170,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -4101,19 +4191,19 @@
       }
     },
     "node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^4.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^25.2.1",
     "mkdirp": "^3.0.1",
     "prettier": "^3.3.2",
-    "tap": "^21.5.0",
+    "tap": "^21.6.2",
     "tshy": "^3.0.2",
     "typedoc": "^0.28.5"
   },
@@ -46,7 +46,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "20 || >=22"
+    "node": "18 || 20 || >=22"
   },
   "tshy": {
     "exports": {


### PR DESCRIPTION
I'd like to re-add support for node 18, as we need to support node 18 in the Sentry SDK, and it's easiest to update minimatch rather than backport all the recent security fixes, but bring node 18 support back there means that these modules need to also support it.

If you object, that's fine, I can revive the fork to just float this patch. It's way less than a fork to support TS, but still, simpler to just keep it in one place.

Related: https://github.com/juliangruber/balanced-match/pull/61