### PR TITLE
Add opt-in { max } mitigation to v2 legacy line

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,6 @@ var escOpen = '\0OPEN'+Math.random()+'\0';
 var escClose = '\0CLOSE'+Math.random()+'\0';
 var escComma = '\0COMMA'+Math.random()+'\0';
 var escPeriod = '\0PERIOD'+Math.random()+'\0';
-var EXPANSION_MAX = 100000;
-
-module.exports.EXPANSION_MAX = EXPANSION_MAX;
 
 function numeric(str) {
   return parseInt(str, 10) == str
@@ -69,7 +66,7 @@ function expandTop(str, options) {
     return [];
 
   options = options || {};
-  var max = options.max == null ? EXPANSION_MAX : options.max;
+  var max = options.max == null ? Infinity : options.max;
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ var escOpen = '\0OPEN'+Math.random()+'\0';
 var escClose = '\0CLOSE'+Math.random()+'\0';
 var escComma = '\0COMMA'+Math.random()+'\0';
 var escPeriod = '\0PERIOD'+Math.random()+'\0';
+var EXPANSION_MAX = 100000;
+
+module.exports.EXPANSION_MAX = EXPANSION_MAX;
 
 function numeric(str) {
   return parseInt(str, 10) == str
@@ -61,9 +64,12 @@ function parseCommaParts(str) {
   return parts;
 }
 
-function expandTop(str) {
+function expandTop(str, options) {
   if (!str)
     return [];
+
+  options = options || {};
+  var max = options.max == null ? EXPANSION_MAX : options.max;
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved
@@ -75,7 +81,7 @@ function expandTop(str) {
     str = '\\{\\}' + str.substr(2);
   }
 
-  return expand(escapeBraces(str), true).map(unescapeBraces);
+  return expand(escapeBraces(str), max, true).map(unescapeBraces);
 }
 
 function embrace(str) {
@@ -92,7 +98,7 @@ function gte(i, y) {
   return i >= y;
 }
 
-function expand(str, isTop) {
+function expand(str, max, isTop) {
   var expansions = [];
 
   var m = balanced('{', '}', str);
@@ -101,11 +107,11 @@ function expand(str, isTop) {
   // no need to expand pre, since it is guaranteed to be free of brace-sets
   var pre = m.pre;
   var post = m.post.length
-    ? expand(m.post, false)
+    ? expand(m.post, max, false)
     : [''];
 
   if (/\$$/.test(m.pre)) {    
-    for (var k = 0; k < post.length; k++) {
+    for (var k = 0; k < post.length && k < max; k++) {
       var expansion = pre+ '{' + m.body + '}' + post[k];
       expansions.push(expansion);
     }
@@ -118,7 +124,7 @@ function expand(str, isTop) {
       // {a},b}
       if (m.post.match(/,(?!,).*\}/)) {
         str = m.pre + '{' + m.body + escClose + m.post;
-        return expand(str);
+        return expand(str, max, true);
       }
       return [str];
     }
@@ -130,7 +136,7 @@ function expand(str, isTop) {
       n = parseCommaParts(m.body);
       if (n.length === 1) {
         // x{{a,b}}y ==> x{a}y x{b}y
-        n = expand(n[0], false).map(embrace);
+        n = expand(n[0], max, false).map(embrace);
         if (n.length === 1) {
           return post.map(function(p) {
             return m.pre + n[0] + p;
@@ -185,12 +191,12 @@ function expand(str, isTop) {
       N = [];
 
       for (var j = 0; j < n.length; j++) {
-        N.push.apply(N, expand(n[j], false));
+        N.push.apply(N, expand(n[j], max, false));
       }
     }
 
     for (var j = 0; j < N.length; j++) {
-      for (var k = 0; k < post.length; k++) {
+      for (var k = 0; k < post.length && expansions.length < max; k++) {
         var expansion = pre + N[j] + post[k];
         if (!isTop || isSequence || expansion)
           expansions.push(expansion);

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -48,3 +48,24 @@ test('alphabetic sequences with step count', function(t) {
   t.end();
 });
 
+test('sequence dos', function(t) {
+  var str = '{1..10}'.repeat(10);
+  var expanded = expand(str);
+  var expanded10 = expand(str, { max: 10 });
+
+  t.equal(expanded.length, 100000, 'expansion is limited');
+  t.deepEqual(expanded10, [
+    '1111111111',
+    '1111111112',
+    '1111111113',
+    '1111111114',
+    '1111111115',
+    '1111111116',
+    '1111111117',
+    '1111111118',
+    '1111111119',
+    '11111111110'
+  ], 'custom max truncates expansion');
+  t.equal(expanded10.length, 10, 'custom max is respected');
+  t.end();
+});

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -50,10 +50,8 @@ test('alphabetic sequences with step count', function(t) {
 
 test('sequence dos', function(t) {
   var str = '{1..10}'.repeat(10);
-  var expanded = expand(str);
   var expanded10 = expand(str, { max: 10 });
 
-  t.equal(expanded.length, 100000, 'expansion is limited');
   t.deepEqual(expanded10, [
     '1111111111',
     '1111111112',
@@ -67,5 +65,8 @@ test('sequence dos', function(t) {
     '11111111110'
   ], 'custom max truncates expansion');
   t.equal(expanded10.length, 10, 'custom max is respected');
+
+  var large = '{1..11}'.repeat(5);
+  t.equal(expand(large).length, 161051, 'default is unbounded');
   t.end();
 });


### PR DESCRIPTION
This PR proposes a minimal backport of the expansion-cap mitigation for GHSA-7h2j-956f-4vf2 / CVE-2026-25547 to the `v2` maintenance line.

What changed:
- add a default expansion cap of `100000`
- allow an optional `{ max }` override
- thread the cap through recursive expansion
- stop appending expansions once the cap is reached
- add a regression test for repeated numeric brace ranges

Why:
- `2.0.3` addresses a separate zero-step-range issue, but does not appear to include the expansion-cap mitigation
- this keeps the patch narrow and aligned with the existing `v2` codebase

References:
- https://github.com/isaacs/brace-expansion/commit/59d12f1e23accdec8c395ca824cf942c1fdea860
- https://github.com/juliangruber/brace-expansion/commit/9e59a7161994e352455097c72f974310ed05ffb9
- https://github.com/juliangruber/brace-expansion/compare/v2.0.2...v2.0.3

Closes #99