### PR TITLE
Add opt-in { max } mitigation to v1 legacy line

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ var escOpen = '\0OPEN'+Math.random()+'\0';
 var escClose = '\0CLOSE'+Math.random()+'\0';
 var escComma = '\0COMMA'+Math.random()+'\0';
 var escPeriod = '\0PERIOD'+Math.random()+'\0';
+var EXPANSION_MAX = 100000;
+
+module.exports.EXPANSION_MAX = EXPANSION_MAX;
 
 function numeric(str) {
   return parseInt(str, 10) == str
@@ -62,9 +65,12 @@ function parseCommaParts(str) {
   return parts;
 }
 
-function expandTop(str) {
+function expandTop(str, options) {
   if (!str)
     return [];
+
+  options = options || {};
+  var max = options.max == null ? EXPANSION_MAX : options.max;
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved
@@ -76,7 +82,7 @@ function expandTop(str) {
     str = '\\{\\}' + str.substr(2);
   }
 
-  return expand(escapeBraces(str), true).map(unescapeBraces);
+  return expand(escapeBraces(str), max, true).map(unescapeBraces);
 }
 
 function identity(e) {
@@ -97,7 +103,7 @@ function gte(i, y) {
   return i >= y;
 }
 
-function expand(str, isTop) {
+function expand(str, max, isTop) {
   var expansions = [];
 
   var m = balanced('{', '}', str);
@@ -111,7 +117,7 @@ function expand(str, isTop) {
     // {a},b}
     if (m.post.match(/,(?!,).*\}/)) {
       str = m.pre + '{' + m.body + escClose + m.post;
-      return expand(str);
+      return expand(str, max, true);
     }
     return [str];
   }
@@ -123,10 +129,10 @@ function expand(str, isTop) {
     n = parseCommaParts(m.body);
     if (n.length === 1) {
       // x{{a,b}}y ==> x{a}y x{b}y
-      n = expand(n[0], false).map(embrace);
+      n = expand(n[0], max, false).map(embrace);
       if (n.length === 1) {
         var post = m.post.length
-          ? expand(m.post, false)
+          ? expand(m.post, max, false)
           : [''];
         return post.map(function(p) {
           return m.pre + n[0] + p;
@@ -141,7 +147,7 @@ function expand(str, isTop) {
   // no need to expand pre, since it is guaranteed to be free of brace-sets
   var pre = m.pre;
   var post = m.post.length
-    ? expand(m.post, false)
+    ? expand(m.post, max, false)
     : [''];
 
   var N;
@@ -185,11 +191,11 @@ function expand(str, isTop) {
       N.push(c);
     }
   } else {
-    N = concatMap(n, function(el) { return expand(el, false) });
+    N = concatMap(n, function(el) { return expand(el, max, false) });
   }
 
   for (var j = 0; j < N.length; j++) {
-    for (var k = 0; k < post.length; k++) {
+    for (var k = 0; k < post.length && expansions.length < max; k++) {
       var expansion = pre + N[j] + post[k];
       if (!isTop || isSequence || expansion)
         expansions.push(expansion);

--- a/index.js
+++ b/index.js
@@ -8,9 +8,6 @@ var escOpen = '\0OPEN'+Math.random()+'\0';
 var escClose = '\0CLOSE'+Math.random()+'\0';
 var escComma = '\0COMMA'+Math.random()+'\0';
 var escPeriod = '\0PERIOD'+Math.random()+'\0';
-var EXPANSION_MAX = 100000;
-
-module.exports.EXPANSION_MAX = EXPANSION_MAX;
 
 function numeric(str) {
   return parseInt(str, 10) == str
@@ -70,7 +67,7 @@ function expandTop(str, options) {
     return [];
 
   options = options || {};
-  var max = options.max == null ? EXPANSION_MAX : options.max;
+  var max = options.max == null ? Infinity : options.max;
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -48,3 +48,25 @@ test('alphabetic sequences with step count', function(t) {
   t.end();
 });
 
+test('sequence dos', function(t) {
+  var str = '{1..10}'.repeat(10);
+  var expanded = expand(str);
+  var expanded10 = expand(str, { max: 10 });
+
+  t.equal(expanded.length, 100000, 'expansion is limited');
+  t.deepEqual(expanded10, [
+    '1111111111',
+    '1111111112',
+    '1111111113',
+    '1111111114',
+    '1111111115',
+    '1111111116',
+    '1111111117',
+    '1111111118',
+    '1111111119',
+    '11111111110'
+  ], 'custom max truncates expansion');
+  t.equal(expanded10.length, 10, 'custom max is respected');
+  t.end();
+});
+

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -50,10 +50,8 @@ test('alphabetic sequences with step count', function(t) {
 
 test('sequence dos', function(t) {
   var str = '{1..10}'.repeat(10);
-  var expanded = expand(str);
   var expanded10 = expand(str, { max: 10 });
 
-  t.equal(expanded.length, 100000, 'expansion is limited');
   t.deepEqual(expanded10, [
     '1111111111',
     '1111111112',
@@ -67,6 +65,9 @@ test('sequence dos', function(t) {
     '11111111110'
   ], 'custom max truncates expansion');
   t.equal(expanded10.length, 10, 'custom max is respected');
+
+  var large = '{1..11}'.repeat(5);
+  t.equal(expand(large).length, 161051, 'default is unbounded');
   t.end();
 });
 


### PR DESCRIPTION
Revise the `v1` backport to keep default behavior unchanged and add only an opt-in `{ max }` option.

This avoids a breaking change on the legacy line while still giving direct consumers a way to limit expansion size if they choose to stay on `v1`.

Included:
- opt-in `{ max }` support
- recursive propagation of `max`
- test coverage for truncation
- test coverage showing default behavior is unchanged

References:
- https://github.com/isaacs/brace-expansion/commit/59d12f1e23accdec8c395ca824cf942c1fdea860
- https://github.com/juliangruber/brace-expansion/commit/9e59a7161994e352455097c72f974310ed05ffb9
- https://nvd.nist.gov/vuln/detail/CVE-2026-25547

Refs #99 #100 
