### PR TITLE
Remove Node.js 18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x, 25.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
         platform:
         - os: ubuntu-latest
           shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typedoc": "^0.28.5"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "18 || 20 || >=22"
+    "node": "20 || >=22"
   },
   "tshy": {
     "exports": {


### PR DESCRIPTION
Node.js 18 is unsupported as in https://nodejs.org/en/about/previous-releases
Need for change discovered in failing CI in https://github.com/juliangruber/brace-expansion/pull/108
Will publish as semver major version