### PR TITLE
fix(package.json): use git+https instead of git+ssh for repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
   "module": "./dist/esm/index.js",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/juliangruber/brace-expansion.git"
+    "url": "git+https://github.com/juliangruber/brace-expansion.git"
   }
 }


### PR DESCRIPTION
## Summary
- Change `repository.url` in `package.json` from `git+ssh://git@github.com/juliangruber/brace-expansion.git` to `git+https://github.com/juliangruber/brace-expansion.git`.
- The package metadata currently exposes an SSH-only GitHub repository URL. For a public repository, the HTTPS form works for everyone (no SSH key requirement).

## Why
- The metadata should let any consumer of `brace-expansion` (downstream packages, security audit tools, package registries) resolve the repository without needing a GitHub SSH key configured.
- The `git+https://` form is the canonical public-URL form that npm and most tooling default to.

## Reproduction
```bash
curl -s https://registry.npmjs.org/brace-expansion | python3 -c 'import json,sys;d=json.loads(sys.stdin.read());v=d["dist-tags"]["latest"];print(d["versions"][v]["repository"]["url"])'
```
Observed: `git+ssh://git@github.com/juliangruber/brace-expansion.git`.

## Fix
```diff
-    "url": "git+ssh://git@github.com/juliangruber/brace-expansion.git"
+    "url": "git+https://github.com/juliangruber/brace-expansion.git`
```

## Validation
- `python3 -c 'import json; json.load(open("package.json"))` → OK
- `git diff --check` → clean
- `git ls-remote https://github.com/juliangruber/brace-expansion.git HEAD` → resolves
- No runtime code / dependency / lockfile / entrypoint / version / homepage / bugs / test changes