### PR TITLE
fix: v1 backport for CVE-2026-14257

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,16 @@ var balanced = require('balanced-match');
 
 module.exports = expandTop;
 
+// `max` caps the *number* of expansions, but not their length. An input like
+// `'{a,b}'.repeat(1500)` keeps the result count low while making every result
+// ~1500 characters long; the result set, and the intermediate arrays built
+// while combining brace sets, then grow large enough to exhaust memory and
+// crash the process (CVE-2026-14257). `MAX_EXPANSION_LENGTH` bounds the total
+// number of characters an expansion may hold at any point, mirroring
+// `EXPANSION_MAX_LENGTH` from the v5.0.8 fix. The limit sits well above any
+// realistic expansion, so legitimate input is unaffected.
+var MAX_EXPANSION_LENGTH = 4000000;
+
 var escSlash = '\0SLASH'+Math.random()+'\0';
 var escOpen = '\0OPEN'+Math.random()+'\0';
 var escClose = '\0CLOSE'+Math.random()+'\0';
@@ -68,6 +78,7 @@ function expandTop(str, options) {
 
   options = options || {};
   var max = options.max == null ? Infinity : options.max;
+  var maxLength = options.maxLength == null ? MAX_EXPANSION_LENGTH : options.maxLength;
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved
@@ -79,7 +90,7 @@ function expandTop(str, options) {
     str = '\\{\\}' + str.substr(2);
   }
 
-  return expand(escapeBraces(str), max, true).map(unescapeBraces);
+  return expand(escapeBraces(str), max, maxLength, true).map(unescapeBraces);
 }
 
 function identity(e) {
@@ -100,7 +111,7 @@ function gte(i, y) {
   return i >= y;
 }
 
-function expand(str, max, isTop) {
+function expand(str, max, maxLength, isTop) {
   var expansions = [];
 
   // The `{a},b}` rewrite below restarts expansion on a rewritten string with
@@ -131,14 +142,22 @@ function expand(str, max, isTop) {
       n = parseCommaParts(m.body);
       if (n.length === 1) {
         // x{{a,b}}y ==> x{a}y x{b}y
-        n = expand(n[0], max, false).map(embrace);
+        n = expand(n[0], max, maxLength, false).map(embrace);
         if (n.length === 1) {
           var post = m.post.length
-            ? expand(m.post, max, false)
+            ? expand(m.post, max, maxLength, false)
             : [''];
-          return post.map(function(p) {
-            return m.pre + n[0] + p;
-          });
+          // Combining the single body with the expanded tail grows output
+          // too, so it is bounded like the main combination loop below.
+          var out = [];
+          var outLength = 0;
+          for (var pi = 0; pi < post.length; pi++) {
+            var combined = m.pre + n[0] + post[pi];
+            if (outLength + combined.length > maxLength) return out;
+            out.push(combined);
+            outLength += combined.length;
+          }
+          return out;
         }
       }
     }
@@ -149,7 +168,7 @@ function expand(str, max, isTop) {
     // no need to expand pre, since it is guaranteed to be free of brace-sets
     var pre = m.pre;
     var post = m.post.length
-      ? expand(m.post, max, false)
+      ? expand(m.post, max, maxLength, false)
       : [''];
 
     var N;
@@ -193,14 +212,21 @@ function expand(str, max, isTop) {
         N.push(c);
       }
     } else {
-      N = concatMap(n, function(el) { return expand(el, max, false) });
+      N = concatMap(n, function(el) { return expand(el, max, maxLength, false) });
     }
 
+    // Bounding total characters (not just the result count) is what keeps
+    // memory flat no matter how many brace groups are chained
+    // (CVE-2026-14257) — this loop is the one place output grows.
+    var length = 0;
     for (var j = 0; j < N.length; j++) {
       for (var k = 0; k < post.length && expansions.length < max; k++) {
         var expansion = pre + N[j] + post[k];
-        if (!isTop || isSequence || expansion)
+        if (!isTop || isSequence || expansion) {
+          if (length + expansion.length > maxLength) return expansions;
           expansions.push(expansion);
+          length += expansion.length;
+        }
       }
     }
 

--- a/test/max-length.js
+++ b/test/max-length.js
@@ -1,0 +1,46 @@
+var test = require('tape');
+var expand = require('..');
+
+// CVE-2026-14257: `max` caps the number of results but not their length, so
+// chaining many brace groups keeps the count under `max` while each result
+// grows with the number of groups. Building the long results (and the
+// intermediate arrays combined along the way) exhausted memory and crashed
+// the process with an uncatchable out-of-memory error.
+test('total expansion length is bounded', function (t) {
+  const str = '{a,b}'.repeat(1500)
+  const startTime = performance.now()
+  const expanded = expand(str)
+  const endTime = performance.now()
+
+  const totalLength = expanded.reduce((sum, s) => sum + s.length, 0)
+  t.ok(totalLength <= 4000000, `expected total length (${totalLength}) to be bounded`)
+  t.ok(expanded.length > 0, 'still returns a (truncated) result')
+  t.ok(expanded.every(s => /^[ab]+$/.test(s)), 'results are valid expansions')
+  t.ok(
+    endTime - startTime < 5000,
+    `expected time (${endTime - startTime}ms) to be less than 5000ms`
+  )
+
+  // The bound is a single accumulator, not a per-level limit, so it holds no
+  // matter how many brace groups are chained - not `groups * maxLength`.
+  for (const groups of [100, 1500]) {
+    const total = expand('{a,b}'.repeat(groups)).reduce((sum, s) => sum + s.length, 0)
+    t.ok(total <= 4000000, `expected total length (${total}) to stay bounded at ${groups} groups`)
+  }
+  t.end()
+})
+
+test('maxLength option bounds output size', function (t) {
+  const str = '{a,b}'.repeat(1500)
+  const expanded = expand(str, { maxLength: 100000 })
+  const totalLength = expanded.reduce((sum, s) => sum + s.length, 0)
+  t.ok(totalLength <= 100000, `expected total length (${totalLength}) to respect maxLength`)
+
+  // The single-body branch (`x{{a,b}}y`) combines its body with the expanded
+  // tail and must be bounded the same way.
+  const single = '{{a,b}}' + '{a,b}'.repeat(20)
+  const expandedSingle = expand(single, { maxLength: 1000 })
+  const singleLength = expandedSingle.reduce((sum, s) => sum + s.length, 0)
+  t.ok(singleLength <= 1000, `expected total length (${singleLength}) to respect maxLength`)
+  t.end()
+})


### PR DESCRIPTION
Backports the v5.0.8 length-bound fix for CVE-2026-14257 (GHSA-mh99-v99m-4gvg) to the v1 branch, following the precedent of #111 and #122.

## What

- New `maxLength` option (default `4000000`, mirroring `EXPANSION_MAX_LENGTH` from v5.0.8) bounding the **total number of characters** an expansion may hold at any point, threaded through the recursion and enforced at every place output grows (main combination loop and the single-body `x{{a,b}}y` branch).
- Regression tests ported from the v5.0.8 test additions, adapted to this branch's tape suite.

## Verification

- Full v1 suite passes: 189/189.
- The advisory PoC (`'{a,b}'.repeat(1500)`) completes with output capped at 3,999,000 chars under `node --max-old-space-size=256`; on unpatched 1.1.16 the same input aborts the process with an uncatchable OOM.

## Notes

- This confirms #131 is mistaken: 1.1.16 has no length bound and crashes on the advisory PoC — the advisory's `<=5.0.7` range is unfortunately accurate until backports like this one are released.
- The iterative tail-expansion (stack-depth) refactor that also landed in 5.0.8 is deliberately **not** ported — it's not part of the CVE and keeping this minimal should make it easy to review.
- Happy to adjust anything (naming, defaults, test placement) to your preference.

Prepared with AI assistance (Claude); the diff and verification runs were reviewed and executed locally.