### PR TITLE
fix: v2 backport for CVE-2026-14257

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,16 @@ var balanced = require('balanced-match');
 
 module.exports = expandTop;
 
+// `max` caps the *number* of expansions, but not their length. An input like
+// `'{a,b}'.repeat(1500)` keeps the result count low while making every result
+// ~1500 characters long; the result set, and the intermediate arrays built
+// while combining brace sets, then grow large enough to exhaust memory and
+// crash the process (CVE-2026-14257). `MAX_EXPANSION_LENGTH` bounds the total
+// number of characters an expansion may hold at any point, mirroring
+// `EXPANSION_MAX_LENGTH` from the v5.0.8 fix. The limit sits well above any
+// realistic expansion, so legitimate input is unaffected.
+var MAX_EXPANSION_LENGTH = 4000000;
+
 var escSlash = '\0SLASH'+Math.random()+'\0';
 var escOpen = '\0OPEN'+Math.random()+'\0';
 var escClose = '\0CLOSE'+Math.random()+'\0';
@@ -67,6 +77,7 @@ function expandTop(str, options) {
 
   options = options || {};
   var max = options.max == null ? Infinity : options.max;
+  var maxLength = options.maxLength == null ? MAX_EXPANSION_LENGTH : options.maxLength;
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved
@@ -78,7 +89,7 @@ function expandTop(str, options) {
     str = '\\{\\}' + str.substr(2);
   }
 
-  return expand(escapeBraces(str), max, true).map(unescapeBraces);
+  return expand(escapeBraces(str), max, maxLength, true).map(unescapeBraces);
 }
 
 function embrace(str) {
@@ -95,7 +106,7 @@ function gte(i, y) {
   return i >= y;
 }
 
-function expand(str, max, isTop) {
+function expand(str, max, maxLength, isTop) {
   var expansions = [];
 
   // The `{a},b}` rewrite below restarts expansion on a rewritten string with
@@ -110,10 +121,15 @@ function expand(str, max, isTop) {
 
     if (/\$$/.test(m.pre)) {
       const post =
-        m.post.length ? expand(m.post, max, false) : ['']
+        m.post.length ? expand(m.post, max, maxLength, false) : ['']
+      // The `${...}` literal combines its body with the expanded tail, so
+      // output grows here too and is bounded like the main loop below.
+      let dollarLength = 0
       for (let k = 0; k < post.length && k < max; k++) {
         const expansion = pre + '{' + m.body + '}' + post[k]
+        if (dollarLength + expansion.length > maxLength) return expansions
         expansions.push(expansion)
+        dollarLength += expansion.length
       }
       return expansions
     }
@@ -137,7 +153,7 @@ function expand(str, max, isTop) {
     // non-expanding `{}`, which is what made inputs like `a{},{},{}...` blow up
     // exponentially.
     const post =
-      m.post.length ? expand(m.post, max, false) : ['']
+      m.post.length ? expand(m.post, max, maxLength, false) : ['']
     var n;
     if (isSequence) {
       n = m.body.split(/\.\./);
@@ -145,11 +161,19 @@ function expand(str, max, isTop) {
       n = parseCommaParts(m.body);
       if (n.length === 1) {
         // x{{a,b}}y ==> x{a}y x{b}y
-        n = expand(n[0], max, false).map(embrace);
+        n = expand(n[0], max, maxLength, false).map(embrace);
         if (n.length === 1) {
-          return post.map(function(p) {
-            return m.pre + n[0] + p;
-          });
+          // Combining the single body with the expanded tail grows output
+          // too, so it is bounded like the main combination loop below.
+          var out = [];
+          var outLength = 0;
+          for (var pi = 0; pi < post.length; pi++) {
+            var combined = m.pre + n[0] + post[pi];
+            if (outLength + combined.length > maxLength) return out;
+            out.push(combined);
+            outLength += combined.length;
+          }
+          return out;
         }
       }
     }
@@ -200,15 +224,22 @@ function expand(str, max, isTop) {
       N = [];
 
       for (var j = 0; j < n.length; j++) {
-        N.push.apply(N, expand(n[j], max, false));
+        N.push.apply(N, expand(n[j], max, maxLength, false));
       }
     }
 
+    // Bounding total characters (not just the result count) is what keeps
+    // memory flat no matter how many brace groups are chained
+    // (CVE-2026-14257) — this loop is the one place output grows.
+    var length = 0;
     for (var j = 0; j < N.length; j++) {
       for (var k = 0; k < post.length && expansions.length < max; k++) {
         var expansion = pre + N[j] + post[k];
-        if (!isTop || isSequence || expansion)
+        if (!isTop || isSequence || expansion) {
+          if (length + expansion.length > maxLength) return expansions;
           expansions.push(expansion);
+          length += expansion.length;
+        }
       }
     }
 

--- a/test/max-length.js
+++ b/test/max-length.js
@@ -1,0 +1,53 @@
+var test = require('tape');
+var expand = require('..');
+
+// CVE-2026-14257: `max` caps the number of results but not their length, so
+// chaining many brace groups keeps the count under `max` while each result
+// grows with the number of groups. Building the long results (and the
+// intermediate arrays combined along the way) exhausted memory and crashed
+// the process with an uncatchable out-of-memory error.
+test('total expansion length is bounded', function (t) {
+  const str = '{a,b}'.repeat(1500)
+  const startTime = performance.now()
+  const expanded = expand(str)
+  const endTime = performance.now()
+
+  const totalLength = expanded.reduce((sum, s) => sum + s.length, 0)
+  t.ok(totalLength <= 4000000, `expected total length (${totalLength}) to be bounded`)
+  t.ok(expanded.length > 0, 'still returns a (truncated) result')
+  t.ok(expanded.every(s => /^[ab]+$/.test(s)), 'results are valid expansions')
+  t.ok(
+    endTime - startTime < 5000,
+    `expected time (${endTime - startTime}ms) to be less than 5000ms`
+  )
+
+  // The bound is a single accumulator, not a per-level limit, so it holds no
+  // matter how many brace groups are chained - not `groups * maxLength`.
+  for (const groups of [100, 1500]) {
+    const total = expand('{a,b}'.repeat(groups)).reduce((sum, s) => sum + s.length, 0)
+    t.ok(total <= 4000000, `expected total length (${total}) to stay bounded at ${groups} groups`)
+  }
+  t.end()
+})
+
+test('maxLength option bounds output size', function (t) {
+  const str = '{a,b}'.repeat(1500)
+  const expanded = expand(str, { maxLength: 100000 })
+  const totalLength = expanded.reduce((sum, s) => sum + s.length, 0)
+  t.ok(totalLength <= 100000, `expected total length (${totalLength}) to respect maxLength`)
+
+  // The `${...}` literal branch combines its body with the expanded tail and
+  // must be bounded the same way.
+  const dollar = '${x}' + '{a,b}'.repeat(20)
+  const expandedDollar = expand(dollar, { maxLength: 1000 })
+  const dollarLength = expandedDollar.reduce((sum, s) => sum + s.length, 0)
+  t.ok(dollarLength <= 1000, `expected total length (${dollarLength}) to respect maxLength`)
+
+  // The single-body branch (`x{{a,b}}y`) combines its body with the expanded
+  // tail and must be bounded the same way.
+  const single = '{{a,b}}' + '{a,b}'.repeat(20)
+  const expandedSingle = expand(single, { maxLength: 1000 })
+  const singleLength = expandedSingle.reduce((sum, s) => sum + s.length, 0)
+  t.ok(singleLength <= 1000, `expected total length (${singleLength}) to respect maxLength`)
+  t.end()
+})


### PR DESCRIPTION
Backports the v5.0.8 length-bound fix for CVE-2026-14257 (GHSA-mh99-v99m-4gvg) to the v2 branch — companion to #132 (v1), following the precedent of #111 and #122.

## What

- New `maxLength` option (default `4000000`, mirroring `EXPANSION_MAX_LENGTH` from v5.0.8) bounding the **total number of characters** an expansion may hold at any point, threaded through the recursion and enforced at every place output grows: the main combination loop, the single-body `x{{a,b}}y` branch, and this branch's `${...}` literal branch (which combines the body with the expanded tail).
- Regression tests ported from the v5.0.8 test additions, adapted to this branch's tape suite (including the `${...}` case).

## Verification

- Full v2 suite passes: 193/193.
- The advisory PoC (`'{a,b}'.repeat(1500)`) completes with output capped at 3,999,000 chars under `node --max-old-space-size=256`; on unpatched 2.1.2 the same input exhausts memory.

## Notes

- The iterative tail-expansion (stack-depth) refactor that also landed in 5.0.8 is deliberately **not** ported — it's not part of the CVE and keeping this minimal should make it easy to review.
- Happy to adjust anything (naming, defaults, test placement) to your preference.

Prepared with AI assistance (Claude); the diff and verification runs were reviewed and executed locally.