### PR TITLE
fix: bound retained expansion memory on v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var escOpen = '\0OPEN'+Math.random()+'\0';
 var escClose = '\0CLOSE'+Math.random()+'\0';
 var escComma = '\0COMMA'+Math.random()+'\0';
 var escPeriod = '\0PERIOD'+Math.random()+'\0';
+var EXPANSION_MAX_LENGTH = 4000000;
+var EXPANSION_RESULT_OVERHEAD = 24;
 
 function numeric(str) {
   return parseInt(str, 10) == str
@@ -67,6 +69,10 @@ function expandTop(str, options) {
 
   options = options || {};
   var max = options.max == null ? Infinity : options.max;
+  var maxLength = options.maxLength == null
+    ? EXPANSION_MAX_LENGTH
+    : Number(options.maxLength);
+  if (maxLength !== maxLength) maxLength = EXPANSION_MAX_LENGTH;
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved
@@ -78,7 +84,7 @@ function expandTop(str, options) {
     str = '\\{\\}' + str.substr(2);
   }
 
-  return expand(escapeBraces(str), max, true).map(unescapeBraces);
+  return expand(escapeBraces(str), max, maxLength, true).map(unescapeBraces);
 }
 
 function embrace(str) {
@@ -95,27 +101,188 @@ function gte(i, y) {
   return i >= y;
 }
 
-function expand(str, max, isTop) {
-  var expansions = [];
+// `maxLength` primarily bounds characters, but every retained result also
+// consumes an array slot and string metadata. Reserve a conservative minimum
+// cost per result so duplicate empty strings cannot bypass the memory bound.
+function resultLimit(maxLength) {
+  if (maxLength === Infinity) return Infinity;
+  if (maxLength <= 0) return 0;
+  return Math.max(1, Math.floor(maxLength / EXPANSION_RESULT_OVERHEAD));
+}
 
-  // The `{a},b}` rewrite below restarts expansion on a rewritten string with
-  // the same `max` and `isTop = true`. Loop instead of recursing so a long run
-  // of non-expanding `{}` groups can't exhaust the call stack.
+function appendValue(
+  out,
+  retained,
+  value,
+  pre,
+  post,
+  max,
+  maxLength,
+  dropEmpties
+) {
+  var countLimit = resultLimit(maxLength);
+  if (!(out.length < max) || out.length >= countLimit) return false;
+
+  for (var k = 0; k < post.length; k++) {
+    if (!(out.length < max) || out.length >= countLimit) return false;
+    var expansion = pre + value + post[k];
+    if (dropEmpties && !expansion) continue;
+    if (retained.length + expansion.length > maxLength) return false;
+    out.push(expansion);
+    retained.length += expansion.length;
+  }
+  return true;
+}
+
+function combineValues(values, pre, post, max, maxLength, dropEmpties) {
+  var out = [];
+  var retained = { length: 0 };
+  for (var j = 0; j < values.length; j++) {
+    if (!appendValue(
+      out,
+      retained,
+      values[j],
+      pre,
+      post,
+      max,
+      maxLength,
+      dropEmpties
+    )) break;
+  }
+  return out;
+}
+
+function combineSingle(pre, post, maxLength) {
+  return combineValues([''], pre, post, Infinity, maxLength, false);
+}
+
+function combineSequence(
+  body,
+  isAlphaSequence,
+  pre,
+  post,
+  max,
+  maxLength,
+  dropEmpties
+) {
+  if (!post.length) return [];
+
+  var n = body.split(/\.\./);
+  var out = [];
+  var retained = { length: 0 };
+  var x = numeric(n[0]);
+  var y = numeric(n[1]);
+  var width = Math.max(n[0].length, n[1].length)
+  var incr = n.length == 3
+    ? Math.max(Math.abs(numeric(n[2])), 1)
+    : 1;
+  var test = lte;
+  var reverse = y < x;
+  if (reverse) {
+    incr *= -1;
+    test = gte;
+  }
+  var pad = n.some(isPadded);
+
+  for (var i = x; test(i, y); i += incr) {
+    var c;
+    if (isAlphaSequence) {
+      c = String.fromCharCode(i);
+      if (c === '\\')
+        c = '';
+    } else {
+      c = String(i);
+      if (pad) {
+        var need = width - c.length;
+        if (need > 0) {
+          var z = new Array(need + 1).join('0');
+          if (i < 0)
+            c = '-' + z + c.slice(1);
+          else
+            c = z + c;
+        }
+      }
+    }
+    if (!appendValue(
+      out,
+      retained,
+      c,
+      pre,
+      post,
+      max,
+      maxLength,
+      dropEmpties
+    )) break;
+  }
+  return out;
+}
+
+function combineOptions(
+  body,
+  pre,
+  post,
+  max,
+  maxLength,
+  dropEmpties
+) {
+  if (!post.length) return [];
+
+  var n = parseCommaParts(body);
+  if (n.length === 1) {
+    // x{{a,b}}y ==> x{a}y x{b}y
+    n = expand(n[0], max, maxLength, false).map(embrace);
+    if (n.length === 1) {
+      return combineSingle(pre + n[0], post, maxLength);
+    }
+  }
+
+  var out = [];
+  var retained = { length: 0 };
+  for (var j = 0; j < n.length; j++) {
+    var additions = expand(n[j], max, maxLength, false);
+    for (var a = 0; a < additions.length; a++) {
+      if (!appendValue(
+        out,
+        retained,
+        additions[a],
+        pre,
+        post,
+        max,
+        maxLength,
+        dropEmpties
+      )) return out;
+    }
+  }
+  return out;
+}
+
+function expand(str, max, maxLength, isTop) {
+  var frames = [];
+  var result;
+
+  // Parse the recursive tail into explicit frames, then fold it right to left.
   for (;;) {
-    const m = balanced('{', '}', str)
-    if (!m) return [str]
+    var m = balanced('{', '}', str);
+    if (!m) {
+      result = [str];
+      break;
+    }
 
     // no need to expand pre, since it is guaranteed to be free of brace-sets
-    const pre = m.pre
+    var pre = m.pre;
 
-    if (/\$$/.test(m.pre)) {
-      const post =
-        m.post.length ? expand(m.post, max, false) : ['']
-      for (let k = 0; k < post.length && k < max; k++) {
-        const expansion = pre + '{' + m.body + '}' + post[k]
-        expansions.push(expansion)
+    if (/\$$/.test(pre)) {
+      frames.push({
+        type: 'dollar',
+        pre: pre + '{' + m.body + '}'
+      });
+      if (m.post.length) {
+        str = m.post;
+        isTop = false;
+        continue;
       }
-      return expansions
+      result = [''];
+      break;
     }
 
     var isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body);
@@ -129,89 +296,57 @@ function expand(str, max, isTop) {
         isTop = true;
         continue;
       }
-      return [str];
+      result = [str];
+      break;
     }
 
-    // Only expand post once we know this brace set actually expands. Computing
-    // it before the early returns above expanded post a second time on every
-    // non-expanding `{}`, which is what made inputs like `a{},{},{}...` blow up
-    // exponentially.
-    const post =
-      m.post.length ? expand(m.post, max, false) : ['']
-    var n;
-    if (isSequence) {
-      n = m.body.split(/\.\./);
-    } else {
-      n = parseCommaParts(m.body);
-      if (n.length === 1) {
-        // x{{a,b}}y ==> x{a}y x{b}y
-        n = expand(n[0], max, false).map(embrace);
-        if (n.length === 1) {
-          return post.map(function(p) {
-            return m.pre + n[0] + p;
-          });
-        }
-      }
+    frames.push({
+      type: 'regular',
+      pre: pre,
+      body: m.body,
+      isAlphaSequence: isAlphaSequence,
+      isSequence: isSequence,
+      dropEmpties: isTop && !isSequence
+    });
+    if (m.post.length) {
+      str = m.post;
+      isTop = false;
+      continue;
     }
-
-    // at this point, n is the parts, and we know it's not a comma set
-    // with a single entry.
-    var N;
-
-    if (isSequence) {
-      var x = numeric(n[0]);
-      var y = numeric(n[1]);
-      var width = Math.max(n[0].length, n[1].length)
-      var incr = n.length == 3
-        ? Math.max(Math.abs(numeric(n[2])), 1)
-        : 1;
-      var test = lte;
-      var reverse = y < x;
-      if (reverse) {
-        incr *= -1;
-        test = gte;
-      }
-      var pad = n.some(isPadded);
-
-      N = [];
-
-      for (var i = x; test(i, y) && N.length < max; i += incr) {
-        var c;
-        if (isAlphaSequence) {
-          c = String.fromCharCode(i);
-          if (c === '\\')
-            c = '';
-        } else {
-          c = String(i);
-          if (pad) {
-            var need = width - c.length;
-            if (need > 0) {
-              var z = new Array(need + 1).join('0');
-              if (i < 0)
-                c = '-' + z + c.slice(1);
-              else
-                c = z + c;
-            }
-          }
-        }
-        N.push(c);
-      }
-    } else {
-      N = [];
-
-      for (var j = 0; j < n.length; j++) {
-        N.push.apply(N, expand(n[j], max, false));
-      }
-    }
-
-    for (var j = 0; j < N.length; j++) {
-      for (var k = 0; k < post.length && expansions.length < max; k++) {
-        var expansion = pre + N[j] + post[k];
-        if (!isTop || isSequence || expansion)
-          expansions.push(expansion);
-      }
-    }
-
-    return expansions;
+    result = [''];
+    break;
   }
+
+  while (frames.length) {
+    var frame = frames.pop();
+    result = frame.type === 'dollar'
+      ? combineValues(
+          [''],
+          frame.pre,
+          result,
+          max,
+          maxLength,
+          false
+        )
+      : frame.isSequence
+      ? combineSequence(
+          frame.body,
+          frame.isAlphaSequence,
+          frame.pre,
+          result,
+          max,
+          maxLength,
+          frame.dropEmpties
+        )
+      : combineOptions(
+          frame.body,
+          frame.pre,
+          result,
+          max,
+          maxLength,
+          frame.dropEmpties
+        );
+  }
+
+  return result;
 }

--- a/test/cve-2026-14257.js
+++ b/test/cve-2026-14257.js
@@ -1,0 +1,145 @@
+var path = require('path');
+var spawnSync = require('child_process').spawnSync;
+var test = require('tape');
+var expand = require('..');
+
+function totalLength(expansions) {
+  return expansions.reduce(function (sum, value) {
+    return sum + value.length;
+  }, 0);
+}
+
+function runChild(heapSize, script) {
+  return spawnSync(
+    process.execPath,
+    ['--max-old-space-size=' + heapSize, '-e', script],
+    {
+      cwd: path.resolve(__dirname, '..'),
+      encoding: 'utf8',
+      timeout: 15000
+    }
+  );
+}
+
+function childDetail(result) {
+  return result.error
+    ? result.error.message
+    : (result.stderr || '').slice(0, 1000);
+}
+
+test('CVE-2026-14257 bounds chained expansion memory', function (t) {
+  var script = [
+    "var expand = require('.');",
+    "var expanded = expand('{a,b}'.repeat(3000));",
+    "var totalLength = expanded.reduce(function (sum, value) {",
+    "  return sum + value.length;",
+    "}, 0);",
+    "if (!expanded.length || totalLength > 4000000) process.exit(2);",
+    "var limited = expand('{a,b}'.repeat(1000), { maxLength: 100000 });",
+    "var limitedLength = limited.reduce(function (sum, value) {",
+    "  return sum + value.length;",
+    "}, 0);",
+    "if (!limited.length || limitedLength > 100000) process.exit(3);"
+  ].join('\n');
+  var result = runChild(512, script);
+
+  t.equal(
+    result.status,
+    0,
+    'long chained output stays within the character budget: ' + childDetail(result)
+  );
+  t.end();
+});
+
+test('empty and sequence intermediates stay bounded', function (t) {
+  [
+    {
+      name: 'zero-length results',
+      script: "var e=require('.');if(e('{,}'.repeat(30)).length)process.exit(4)"
+    },
+    {
+      name: 'invalid maxLength fallback',
+      script: "var e=require('.');if(e('{,}'.repeat(30),{maxLength:'invalid'}).length)process.exit(5)"
+    },
+    {
+      name: 'single wide sequence',
+      script: "var e=require('.'),o=e('{1..100000000}'),n=o.reduce(function(s,v){return s+v.length},0);if(!o.length||n>4000000)process.exit(6)"
+    },
+    {
+      name: 'chained wide sequences',
+      script: "var e=require('.'),o=e('{1..100000}'.repeat(20)),n=o.reduce(function(s,v){return s+v.length},0);if(!o.length||n>4000000)process.exit(7)"
+    }
+  ].forEach(function (regression) {
+    var result = runChild(64, regression.script);
+    t.equal(
+      result.status,
+      0,
+      regression.name + ' stays within a 64 MB heap: ' + childDetail(result)
+    );
+  });
+  t.end();
+});
+
+test('total expansion length uses one global bound', function (t) {
+  [100, 1500, 5000].forEach(function (groups) {
+    var start = Date.now();
+    var expanded = expand('{a,b}'.repeat(groups));
+    var length = totalLength(expanded);
+
+    t.ok(expanded.length > 0, groups + ' groups still return results');
+    t.ok(length <= 4000000, groups + ' groups stay within the default bound');
+    t.ok(
+      expanded.every(function (value) { return /^[ab]+$/.test(value); }),
+      groups + ' groups return only valid expansions'
+    );
+    t.ok(Date.now() - start < 5000, groups + ' groups complete promptly');
+  });
+
+  t.doesNotThrow(function () {
+    expand('{a,b}'.repeat(50000));
+  }, 'deep chaining does not overflow the stack');
+  t.end();
+});
+
+test('maxLength option sets a smaller global bound', function (t) {
+  var expanded = expand('{a,b}'.repeat(1500), { maxLength: 100000 });
+  var dollar = expand('${x}' + '{a,b}'.repeat(20), { maxLength: 100000 });
+  var prefixInput = '{a,b}'.repeat(10);
+  var unbounded = expand(prefixInput, { maxLength: Infinity });
+  var prefix = expand(prefixInput, { maxLength: 100 });
+
+  t.ok(expanded.length > 0, 'custom limit still returns results');
+  t.ok(totalLength(expanded) <= 100000, 'custom length limit is respected');
+  t.ok(dollar.length > 0, 'dollar expression still returns results');
+  t.ok(totalLength(dollar) <= 100000, 'dollar-expression tail shares the bound');
+  t.deepEqual(
+    prefix,
+    unbounded.slice(0, prefix.length),
+    'truncation preserves expansion order'
+  );
+  t.end();
+});
+
+test('v2 dollar-expression behavior is unchanged', function (t) {
+  t.deepEqual(
+    expand('${a,b}${c,d}{e,f}'),
+    ['${a,b}${c,d}e', '${a,b}${c,d}f'],
+    'later braces still expand after dollar expressions'
+  );
+  t.end();
+});
+
+test('legacy finite-max behavior is unchanged', function (t) {
+  t.deepEqual(
+    expand('{,x}'.repeat(4), { max: 5 }),
+    ['x', 'x', 'xx', 'x', 'x'],
+    'suffix-first truncation order is preserved'
+  );
+  t.deepEqual(expand('a', { max: 0 }), ['a'], 'max zero leaves literals alone');
+  t.deepEqual(
+    expand('{,,,,a,b}', { max: 1 }),
+    ['a'],
+    'discarded empty options do not consume the finite max'
+  );
+  t.end();
+});


### PR DESCRIPTION
## Summary

Backport the CVE-2026-14257 / GHSA-mh99-v99m-4gvg retained-expansion memory
defense to the v2 maintenance line while preserving its callable CommonJS API
and legacy expansion order.

- defaults `maxLength` to 4,000,000 total retained characters;
- additionally caps retained result slots at `floor(maxLength / 24)` so empty
  strings cannot bypass a character-only limit;
- parses chained groups into raw descriptors and folds them right to left;
- generates and charges sequence values lazily instead of materializing the
  whole range first;
- keeps the legacy public `max` default at `Infinity`; callers can explicitly
  opt out of the new internal budget with `maxLength: Infinity`;
- changes only `index.js` and `test/cve-2026-14257.js`—no version, dependency,
  lockfile, or package-publication change.

## Why this is distinct from #130

I paused publication when #130 appeared and executed its exact head
`0772fdd`. Four deterministic gaps remain:

- `'{,}'.repeat(30)` exits 134 under a 64 MB heap because zero-length results
  bypass its character-only accumulator;
- `'{1..100000000}'` exits 134 under a 64 MB heap because the full sequence is
  materialized before the accumulator can bound it;
- `'{,x}{,x}{,x}{,x}'` with `{ max: 5 }` changes the legacy fifth result from
  `x` to `xx`;
- expanding literal `a` with `{ max: 0 }` changes from `['a']` to `[]`.

The regression suite here exercises each allocation path in its own 64 MB
child and locks the legacy finite-`max` cases.

## Validation

- CVE/security and compatibility tests: 27/27
- existing non-fixture core tests: 38/38
- normalized Bash corpus: 146/146
- deterministic differential comparison with the v2 base: 400,000/400,000
  ordinary cases exact
- bounded large case: exact ordered prefix 166,666/320,000; explicit
  `maxLength: Infinity`: exact 320,000/320,000
- packed-package smoke: callable API and `minimatch@9.0.9`; the advisory
  payload stayed at 3,999,000 characters under a 512 MB heap
- independent read-only security review: approved

The repository's complete `npm test` is baseline-red on the committed
CRLF-sensitive Bash fixture (65 pass / 146 fail). Removing `\r` in memory
makes all 146 fixture cases pass; this PR does not modify that fixture or its
harness.

## Maintainer follow-up

If this approach is accepted, please publish the next v2 patch release and add
its disjoint patched range to the GitHub advisory. This PR does not merge,
release, publish, or alter advisory metadata.
