### PR TITLE
fix: backport GHSA-mh99-v99m-4gvg to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,33 @@ expand('ppp{,config,oe{,conf}}')
 import expand from 'brace-expansion'
 ```
 
-### const expanded = expand(str)
+### const expanded = expand(str, [options])
 
 Return an array of all possible and valid expansions of `str`. If none are
 found, `[str]` is returned.
+
+The `options` object can provide a `max` value to cap the number
+of expansions allowed. It defaults to `Infinity`, preserving this
+release line's published behavior.
+
+```js
+const expansions = expand('{1..100}'.repeat(5), {
+  max: 100,
+})
+// expansions.length will be 100, not 100^5
+```
+
+The `options` object can also provide a `maxLength` value to cap the
+total number of characters across all expansions. This is limited to
+`4_000_000` by default, to prevent memory exhaustion from inputs whose
+result count stays under `max` while each result grows very long.
+
+```js
+const expansions = expand('{a,b}'.repeat(1500), {
+  maxLength: 100,
+})
+// the combined length of expansions will not exceed 100 characters
+```
 
 Valid expansions are:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ const expansions = expand('{1..100}'.repeat(5), {
 // expansions.length will be 100, not 100^5
 ```
 
+`max` defaults to `Infinity` on the 3.x line for compatibility, which
+means a single very large sequence such as `{1..100000000}` can still
+exhaust memory. Pass `{ max: 100000 }` to match the 4.x/5.x default.
+
 The `options` object can also provide a `maxLength` value to cap the
 total number of characters across all expansions. This is limited to
 `4_000_000` by default, to prevent memory exhaustion from inputs whose

--- a/index.js
+++ b/index.js
@@ -6,6 +6,24 @@ const escClose = '\0CLOSE' + Math.random() + '\0'
 const escComma = '\0COMMA' + Math.random() + '\0'
 const escPeriod = '\0PERIOD' + Math.random() + '\0'
 
+// The modern release lines cap this at 100_000, but the 3.x line never
+// capped the number of expansions, so it defaults to Infinity to preserve
+// published behavior. Pass the `max` option to opt in to a cap.
+export const EXPANSION_MAX = Infinity
+
+// `EXPANSION_MAX` caps the *number* of expansions, but not their length. An
+// input like `'{a,b}'.repeat(1500)` stays under any such cap - and expands
+// freely under this line's Infinity default - while making every result
+// ~1500 characters long. The result set, and the intermediate arrays built
+// while combining brace sets, then grow large enough to exhaust memory and
+// crash the process (CVE-2026-14257). `EXPANSION_MAX_LENGTH` bounds the
+// total number of characters the accumulator may hold at any point, so
+// memory stays flat no matter how many brace groups are chained. The limit
+// sits well above any realistic expansion (100k results hitting the modern
+// lines' `EXPANSION_MAX` measure ~1M characters) so legitimate input is
+// unaffected.
+export const EXPANSION_MAX_LENGTH = 4_000_000
+
 /**
  * @return {number}
  */
@@ -70,12 +88,10 @@ function parseCommaParts (str) {
  * @param {string} str
  * @param {{max?: number, maxLength?: number}} [options]
  */
-export default function expandTop (str, options) {
+export default function expandTop (str, options = {}) {
   if (!str) { return [] }
 
-  options = options || {}
-  const max = options.max == null ? Infinity : options.max
-  const maxLength = options.maxLength == null ? 4_000_000 : options.maxLength
+  const { max = EXPANSION_MAX, maxLength = EXPANSION_MAX_LENGTH } = options
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved
@@ -172,7 +188,7 @@ function expandSequence (body, isAlphaSequence, max) {
   const x = numeric(n[0])
   const y = numeric(n[1])
   const width = Math.max(n[0].length, n[1].length)
-  let incr = n.length === 3
+  let incr = n.length === 3 && n[2] !== undefined
     ? Math.max(Math.abs(numeric(n[2])), 1)
     : 1
   let test = lte
@@ -251,7 +267,7 @@ function expand (str, max, maxLength, isTop) {
     if (!isSequence && !isOptions) {
       // {a},b}
       if (m.post.match(/,(?!,).*\}/)) {
-        str = pre + '{' + m.body + escClose + m.post
+        str = m.pre + '{' + m.body + escClose + m.post
         isTop = true
         continue
       }
@@ -269,15 +285,18 @@ function expand (str, max, maxLength, isTop) {
       values = expandSequence(m.body, isAlphaSequence, max)
     } else {
       let n = parseCommaParts(m.body)
-      if (n.length === 1) {
+      if (n.length === 1 && n[0] !== undefined) {
         // x{{a,b}}y ==> x{a}y x{b}y
         n = expand(n[0], max, maxLength, false).map(embrace)
+        // XXX is this necessary? Can't seem to hit it in tests.
+        /* c8 ignore start */
         if (n.length === 1) {
           acc = combine(acc, pre + n[0], [''], max, maxLength, dropEmpties && !m.post.length)
           if (!m.post.length) break
           str = m.post
           continue
         }
+        /* c8 ignore stop */
       }
       values = []
       for (let j = 0; j < n.length; j++) {

--- a/index.js
+++ b/index.js
@@ -68,9 +68,14 @@ function parseCommaParts (str) {
 
 /**
  * @param {string} str
+ * @param {{max?: number, maxLength?: number}} [options]
  */
-export default function expandTop (str) {
+export default function expandTop (str, options) {
   if (!str) { return [] }
+
+  options = options || {}
+  const max = options.max == null ? Infinity : options.max
+  const maxLength = options.maxLength == null ? 4_000_000 : options.maxLength
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved
@@ -82,7 +87,7 @@ export default function expandTop (str) {
     str = '\\{\\}' + str.slice(2)
   }
 
-  return expand(escapeBraces(str), true).map(unescapeBraces)
+  return expand(escapeBraces(str), max, maxLength, true).map(unescapeBraces)
 }
 
 /**
@@ -116,28 +121,129 @@ function gte (i, y) {
 }
 
 /**
+ * Build `{ acc[a] + pre + values[v] }` for every combination, capping the
+ * number of results at `max` and the total number of characters at `maxLength`.
+ * This is the one place output grows, so bounding it here keeps the single
+ * accumulator - and therefore memory - flat regardless of how many brace groups
+ * are combined (CVE-2026-14257).
+ * @param {string[]} acc
+ * @param {string} pre
+ * @param {string[]} values
+ * @param {number} max
+ * @param {number} maxLength
+ * @param {boolean} dropEmpties
+ */
+function combine (acc, pre, values, max, maxLength, dropEmpties) {
+  const out = []
+  let length = 0
+  for (let a = 0; a < acc.length; a++) {
+    for (let v = 0; v < values.length; v++) {
+      if (out.length >= max) return out
+      const expansion = acc[a] + pre + values[v]
+      // Bash drops empty results at the top level. Skip them before they count
+      // against `max`, so `max` bounds the number of *kept* results.
+      if (dropEmpties && !expansion) continue
+      if (length + expansion.length > maxLength) return out
+      out.push(expansion)
+      length += expansion.length
+    }
+  }
+  return out
+}
+
+/**
+ * The expansion values of a single numeric (`1..5`) or alphabetic (`a..e..2`)
+ * sequence body.
+ * @param {string} body
+ * @param {boolean} isAlphaSequence
+ * @param {number} max
+ */
+function expandSequence (body, isAlphaSequence, max) {
+  const n = body.split(/\.\./)
+  /** @type {string[]} */
+  const N = []
+  // A sequence body always splits into two or three parts, but the compiler
+  // can't know that.
+  /* c8 ignore start */
+  if (n[0] === undefined || n[1] === undefined) {
+    return N
+  }
+  /* c8 ignore stop */
+  const x = numeric(n[0])
+  const y = numeric(n[1])
+  const width = Math.max(n[0].length, n[1].length)
+  let incr = n.length === 3
+    ? Math.max(Math.abs(numeric(n[2])), 1)
+    : 1
+  let test = lte
+  const reverse = y < x
+  if (reverse) {
+    incr *= -1
+    test = gte
+  }
+  const pad = n.some(isPadded)
+
+  for (let i = x; test(i, y) && N.length < max; i += incr) {
+    let c
+    if (isAlphaSequence) {
+      c = String.fromCharCode(i)
+      if (c === '\\') { c = '' }
+    } else {
+      c = String(i)
+      if (pad) {
+        const need = width - c.length
+        if (need > 0) {
+          const z = new Array(need + 1).join('0')
+          if (i < 0) { c = '-' + z + c.slice(1) } else { c = z + c }
+        }
+      }
+    }
+    N.push(c)
+  }
+  return N
+}
+
+/**
  * @param {string} str
+ * @param {number} max
+ * @param {number} maxLength
  * @param {boolean} [isTop]
  */
-function expand (str, isTop) {
-  /** @type {string[]} */
-  const expansions = []
+function expand (str, max, maxLength, isTop) {
+  // Consume the string's top-level brace groups left to right, threading a
+  // running set of combined prefixes (`acc`). Expanding the tail iteratively -
+  // rather than recursing on `m.post` once per group - keeps the native stack
+  // depth constant, so deeply chained input (`'{a,b}'.repeat(3000)`) can no
+  // longer overflow the stack, and leaves a single accumulator whose size
+  // `maxLength` bounds directly (CVE-2026-14257).
+  let acc = ['']
 
-  const m = balanced('{', '}', str)
-  if (!m) return [str]
+  // Bash drops empty results, but only when the *first* top-level group is a
+  // comma set - a sequence like `{a..\}` may legitimately yield ''. The drop
+  // is on the final strings, so it is applied to whichever `combine` produces
+  // them (the one with no brace set left in the tail).
+  let dropEmpties = false
+  let firstGroup = true
 
-  // no need to expand pre, since it is guaranteed to be free of brace-sets
-  const pre = m.pre
-  const post = m.post.length
-    ? expand(m.post, false)
-    : ['']
+  for (;;) {
+    const m = balanced('{', '}', str)
 
-  if (/\$$/.test(m.pre)) {
-    for (let k = 0; k < post.length; k++) {
-      const expansion = pre + '{' + m.body + '}' + post[k]
-      expansions.push(expansion)
+    // No brace set left: the rest of the string is literal.
+    if (!m) {
+      return combine(acc, str, [''], max, maxLength, dropEmpties)
     }
-  } else {
+
+    // no need to expand pre, since it is guaranteed to be free of brace-sets
+    const pre = m.pre
+
+    if (/\$$/.test(pre)) {
+      acc = combine(acc, pre + '{' + m.body + '}', [''], max, maxLength, dropEmpties && !m.post.length)
+      firstGroup = false
+      if (!m.post.length) break
+      str = m.post
+      continue
+    }
+
     const isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body)
     const isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body)
     const isSequence = isNumericSequence || isAlphaSequence
@@ -145,81 +251,44 @@ function expand (str, isTop) {
     if (!isSequence && !isOptions) {
       // {a},b}
       if (m.post.match(/,(?!,).*\}/)) {
-        str = m.pre + '{' + m.body + escClose + m.post
-        return expand(str)
+        str = pre + '{' + m.body + escClose + m.post
+        isTop = true
+        continue
       }
-      return [str]
+      // Nothing here expands, so the whole remaining string is literal.
+      return combine(acc, pre + '{' + m.body + '}' + m.post, [''], max, maxLength, dropEmpties)
     }
 
-    let n
+    if (firstGroup) {
+      dropEmpties = isTop && !isSequence
+      firstGroup = false
+    }
+
+    let values
     if (isSequence) {
-      n = m.body.split(/\.\./)
+      values = expandSequence(m.body, isAlphaSequence, max)
     } else {
-      n = parseCommaParts(m.body)
+      let n = parseCommaParts(m.body)
       if (n.length === 1) {
         // x{{a,b}}y ==> x{a}y x{b}y
-        n = expand(n[0], false).map(embrace)
+        n = expand(n[0], max, maxLength, false).map(embrace)
         if (n.length === 1) {
-          return post.map(function (p) {
-            return m.pre + n[0] + p
-          })
+          acc = combine(acc, pre + n[0], [''], max, maxLength, dropEmpties && !m.post.length)
+          if (!m.post.length) break
+          str = m.post
+          continue
         }
       }
-    }
-
-    // at this point, n is the parts, and we know it's not a comma set
-    // with a single entry.
-    let N
-
-    if (isSequence) {
-      const x = numeric(n[0])
-      const y = numeric(n[1])
-      const width = Math.max(n[0].length, n[1].length)
-      let incr = n.length === 3
-        ? Math.max(Math.abs(numeric(n[2])), 1)
-        : 1
-      let test = lte
-      const reverse = y < x
-      if (reverse) {
-        incr *= -1
-        test = gte
-      }
-      const pad = n.some(isPadded)
-
-      N = []
-
-      for (let i = x; test(i, y); i += incr) {
-        let c
-        if (isAlphaSequence) {
-          c = String.fromCharCode(i)
-          if (c === '\\') { c = '' }
-        } else {
-          c = String(i)
-          if (pad) {
-            const need = width - c.length
-            if (need > 0) {
-              const z = new Array(need + 1).join('0')
-              if (i < 0) { c = '-' + z + c.slice(1) } else { c = z + c }
-            }
-          }
-        }
-        N.push(c)
-      }
-    } else {
-      N = []
-
+      values = []
       for (let j = 0; j < n.length; j++) {
-        N.push.apply(N, expand(n[j], false))
+        values.push.apply(values, expand(n[j], max, maxLength, false))
       }
     }
 
-    for (let j = 0; j < N.length; j++) {
-      for (let k = 0; k < post.length; k++) {
-        const expansion = pre + N[j] + post[k]
-        if (!isTop || isSequence || expansion) { expansions.push(expansion) }
-      }
-    }
+    acc = combine(acc, pre, values, max, maxLength, dropEmpties && !m.post.length)
+    if (!m.post.length) break
+    str = m.post
   }
 
-  return expansions
+  return acc
 }

--- a/test/cve.js
+++ b/test/cve.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-template-curly-in-string */
+
+import test from 'node:test'
+import assert from 'assert'
+import expand from '../index.js'
+
+// CVE-2026-14257: `max` caps the number of results but not their length, so
+// chaining many brace groups keeps the count under `max` while each result
+// grows with the number of groups. Building 100k long results (and the
+// intermediate arrays combined along the way) exhausted memory and crashed
+// the process with an uncatchable out-of-memory error.
+test('total expansion length is bounded', function () {
+  const str = '{a,b}'.repeat(1500)
+  const startTime = performance.now()
+  const expanded = expand(str)
+  const endTime = performance.now()
+
+  const totalLength = expanded.reduce((sum, s) => sum + s.length, 0)
+  assert.ok(
+    totalLength <= 4_000_000,
+    `Expected total length (${totalLength}) to be bounded`
+  )
+  assert.ok(expanded.length > 0, 'still returns a (truncated) result')
+  assert.ok(
+    expanded.every(s => /^[ab]+$/.test(s)),
+    'results are valid expansions'
+  )
+  assert.ok(
+    endTime - startTime < 5000,
+    `Expected time (${endTime - startTime}ms) to be less than 5000ms`
+  )
+
+  // The bound is a single accumulator, not a per-level limit, so it holds no
+  // matter how many brace groups are chained - not `groups * maxLength`.
+  for (const groups of [100, 1500, 5000]) {
+    const total = expand('{a,b}'.repeat(groups)).reduce(
+      (sum, s) => sum + s.length,
+      0
+    )
+    assert.ok(
+      total <= 4_000_000,
+      `Expected total length (${total}) to stay bounded at ${groups} groups`
+    )
+  }
+})
+
+// Expanding the tail iteratively (rather than recursing once per brace group)
+// keeps native stack depth constant, so deeply chained input that used to throw
+// `RangeError: Maximum call stack size exceeded` around ~2,700 groups now
+// returns a bounded result.
+test('deep chaining does not overflow the stack', function () {
+  const str = '{a,b}'.repeat(50_000)
+  assert.doesNotThrow(() => {
+    const expanded = expand(str)
+    assert.ok(expanded.length > 0, 'still returns a (truncated) result')
+    assert.ok(
+      expanded.reduce((sum, s) => sum + s.length, 0) <= 4_000_000,
+      'output stays bounded'
+    )
+  })
+})
+
+test('maxLength option bounds output size', function () {
+  const str = '{a,b}'.repeat(1500)
+  const expanded = expand(str, { maxLength: 100_000 })
+  const totalLength = expanded.reduce((sum, s) => sum + s.length, 0)
+  assert.ok(
+    totalLength <= 100_000,
+    `Expected total length (${totalLength}) to respect maxLength`
+  )
+
+  // The `${...}` literal branch combines its body with the expanded tail and
+  // must be bounded the same way.
+  const dollar = '${x}' + '{a,b}'.repeat(20)
+  const expandedDollar = expand(dollar, { maxLength: 100_000 })
+  const dollarLength = expandedDollar.reduce((sum, s) => sum + s.length, 0)
+  assert.ok(
+    dollarLength <= 100_000,
+    `Expected total length (${dollarLength}) to respect maxLength`
+  )
+})
+
+test('max option caps the number of results', function () {
+  assert.deepStrictEqual(expand('{a,b,c,d,e}', { max: 2 }), ['a', 'b'])
+})

--- a/test/cve.js
+++ b/test/cve.js
@@ -2,7 +2,7 @@
 
 import test from 'node:test'
 import assert from 'assert'
-import expand from '../index.js'
+import expand, { EXPANSION_MAX_LENGTH } from '../index.js'
 
 // CVE-2026-14257: `max` caps the number of results but not their length, so
 // chaining many brace groups keeps the count under `max` while each result
@@ -17,7 +17,7 @@ test('total expansion length is bounded', function () {
 
   const totalLength = expanded.reduce((sum, s) => sum + s.length, 0)
   assert.ok(
-    totalLength <= 4_000_000,
+    totalLength <= EXPANSION_MAX_LENGTH,
     `Expected total length (${totalLength}) to be bounded`
   )
   assert.ok(expanded.length > 0, 'still returns a (truncated) result')
@@ -38,7 +38,7 @@ test('total expansion length is bounded', function () {
       0
     )
     assert.ok(
-      total <= 4_000_000,
+      total <= EXPANSION_MAX_LENGTH,
       `Expected total length (${total}) to stay bounded at ${groups} groups`
     )
   }
@@ -54,7 +54,7 @@ test('deep chaining does not overflow the stack', function () {
     const expanded = expand(str)
     assert.ok(expanded.length > 0, 'still returns a (truncated) result')
     assert.ok(
-      expanded.reduce((sum, s) => sum + s.length, 0) <= 4_000_000,
+      expanded.reduce((sum, s) => sum + s.length, 0) <= EXPANSION_MAX_LENGTH,
       'output stays bounded'
     )
   })
@@ -82,4 +82,14 @@ test('maxLength option bounds output size', function () {
 
 test('max option caps the number of results', function () {
   assert.deepStrictEqual(expand('{a,b,c,d,e}', { max: 2 }), ['a', 'b'])
+})
+
+// The iterative algorithm keeps `isTop` across the `{a},b}` rewrite, where
+// published 3.0.2's `return expand(str)` dropped it - so empty comma-parts
+// are now dropped after the rewrite. Bash agrees (`{a},}` expands to `a}`
+// alone), and upstream 5.0.8 behaves identically. This is the only observable
+// behavior change from 3.0.2; pin it so it stays deliberate.
+test('empty results are dropped after the {a},b} rewrite', function () {
+  assert.deepStrictEqual(expand('{a},}'), ['a}'])
+  assert.deepStrictEqual(expand('{a},,b}'), ['a}', 'b'])
 })


### PR DESCRIPTION
Backports the GHSA-mh99-v99m-4gvg / CVE-2026-14257 fix (5.0.8's bounded, iterative expansion) to the `v3` line — the same approach as #129 (v1) and #130 (v2), which currently leave 3.x as the last line with an open backport gap (no `v4` branch exists to target, so 4.x would need a maintainer-created base).

Unlike v1/v2, the v3 line never received the earlier count-cap backport either, so this introduces both options on the default export with behavior-preserving defaults, matching #129/#130: `max` (default `Infinity`) and `maxLength` (default `4_000_000`).

### What's in the diff

- `index.js`: `expand` rewritten to the 5.0.8 iterative algorithm, mirroring a1bd339 line-for-line where the fix touched code (exported `EXPANSION_MAX` / `EXPANSION_MAX_LENGTH` constants with the canonical comment block, destructured option defaults, `combine` / `expandSequence` / iterative tail loop verbatim); code the canonical fix didn't touch stays in this line's own style (ESM, `standard`). Export shape unchanged: callable ESM default.
- `README.md`: options docs ported from the canonical fix — `expand(str, [options])` plus the `max` and `maxLength` sections, with notes on this line's `Infinity` default (see below).
- `test/cve.js`: regression tests ported from #130 (bounded total length across 100/1500/5000 chained groups, deep-chaining stack safety at 50k groups, `maxLength` option incl. the `${…}` literal branch), a small `max` option test since that option is new to this line, and a test pinning the conformance change below. Bounds assert against the exported `EXPANSION_MAX_LENGTH`.

### Behavior change vs published 3.0.2

The iterative algorithm keeps `isTop` across the `{a},b}` escClose rewrite, where 3.0.2's `return expand(str)` dropped it — so empty comma-parts are now dropped after the rewrite: `expand('{a},}')` → `['a}']` (3.0.2: `['a}', '']`), `expand('{a},,b}')` → `['a}', 'b']`. This matches bash and upstream 5.0.8 exactly (confirmed by review differential fuzzing across 402k inputs), so it is a strict conformance improvement inherited from the canonical fix. It is the only observable difference from 3.0.2 besides the new options, and is pinned by a dedicated test in `test/cve.js`.

### Residual scope of the `Infinity` default

`maxLength` bounds the `combine` accumulator, but sequence values are materialized under `max` alone — so with this line's compatibility default of `max: Infinity`, a single very large sequence such as `{1..100000000}` can still exhaust memory. Documented in the README with a pointer to `{ max: 100000 }`, which matches the 4.x/5.x default and upstream behavior exactly.

### Verification

- Full suite: 19/19 pass (`standard` + `node --test`), including `bash-comparison`, `redos` (the prior GHSA-f886-m6hf-6m8v backport), `empty-option`, `nested`, `order`.
- Advisory vector, subprocess capped with `--max-old-space-size=128`, Node v25.9.0:
  - published `3.0.2`: fatal OOM abort on `'{a,b}'.repeat(1500)` (~7.5 KB input)
  - this branch: bounded — 2,666 results / 3,999,000 total chars in ~300 ms, matching `5.0.8` and the #129/#130 branches exactly (I verified those two the same way; happy to share the harness)
