### PR TITLE
chore: ensure prettier formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
       - '*.json'
       - '*.js'
       - '*.ts'
+      - '*.md'
+      - '.prettierignore'
       - 'lib/**'
       - 'scripts/**'
       - '.github/workflows/ci.yml'
@@ -20,6 +22,24 @@ permissions:
   contents: read
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Use Nodejs 24.x
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
   build:
     strategy:
       matrix:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,4 +3,3 @@
 To report a security vulnerability, please use the
 [Tidelift security contact](https://tidelift.com/security).
 Tidelift will coordinate the fix and disclosure.
-

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "tap",
     "snap": "tap",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "benchmark": "node benchmark/index.js",
     "typedoc": "typedoc --tsconfig .tshy/esm.json ./src/*.ts"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,9 @@ export function expand(str: string, options: BraceExpansionOptions = {}) {
     str = '\\{\\}' + str.slice(2)
   }
 
-  return expand_(escapeBraces(str), max, maxLength, true).map(unescapeBraces)
+  return expand_(escapeBraces(str), max, maxLength, true).map(
+    unescapeBraces,
+  )
 }
 
 function embrace(str: string) {
@@ -337,7 +339,10 @@ function expand_(
         for (let k = 0; k < expanded.length; k++) {
           const v = expanded[k] as string
           if (dropsEmpties && !v) continue
-          if (values.length >= max || valuesLength + v.length > maxLength) {
+          if (
+            values.length >= max ||
+            valuesLength + v.length > maxLength
+          ) {
             break outer
           }
           values.push(v)
@@ -346,7 +351,14 @@ function expand_(
       }
     }
 
-    acc = combine(acc, pre, values, max, maxLength, dropEmpties && !m.post.length)
+    acc = combine(
+      acc,
+      pre,
+      values,
+      max,
+      maxLength,
+      dropEmpties && !m.post.length,
+    )
     if (!m.post.length) break
     str = m.post
   }


### PR DESCRIPTION
`npm run format` was not clean on `main`, `prettier --write .` produced changes in two files. Also adding a CI check for this.